### PR TITLE
fix: update staging D1 database configuration

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -15,7 +15,7 @@
         "eslint": "^8.51.0",
         "jest": "^29.7.0",
         "jest-environment-miniflare": "^2.14.1",
-        "wrangler": "^3.0.0"
+        "wrangler": "^3.101.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -19,6 +19,6 @@
     "eslint": "^8.51.0",
     "jest": "^29.7.0",
     "jest-environment-miniflare": "^2.14.1",
-    "wrangler": "^3.0.0"
+    "wrangler": "^3.101.0"
   }
 }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -18,6 +18,7 @@ bucket_name = "sync-storage"
 
 [env.staging]
 name = "chroniclesync-worker-staging"
+zone_id = "ef68ebac5221773b48c1e308c7f599ac"
 routes = [
   { pattern = "api-staging.chroniclesync.xyz", custom_domain = true }
 ]
@@ -25,7 +26,7 @@ routes = [
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "sync_db_staging"
-database_id = "your-staging-d1-database-id"
+database_id = "7cfdcb13-18ba-4a6d-85c3-0c75466debfc"
 
 [[env.staging.r2_buckets]]
 binding = "STORAGE"


### PR DESCRIPTION
This PR updates the staging D1 database configuration with the correct database ID and updates dependencies.

Changes:
- Updated staging D1 database ID to the correct value
- Updated wrangler and other dependencies
- Successfully deployed to staging environment

Deployment verification:
- Worker name: chroniclesync-worker-staging
- Custom domain: api-staging.chroniclesync.xyz
- D1 Database: sync_db_staging (ID: 7cfdcb13-18ba-4a6d-85c3-0c75466debfc)
- R2 Bucket: sync-storage-staging