### PR TITLE
fix: add staging environment configuration for Pages

### DIFF
--- a/pages/package.json
+++ b/pages/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "wrangler pages dev src",
-    "deploy": "wrangler pages deploy src",
+    "deploy": "wrangler pages deploy src --project-name chroniclesync-pages",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/pages/wrangler.toml
+++ b/pages/wrangler.toml
@@ -1,4 +1,9 @@
 name = "chroniclesync-pages"
 compatibility_date = "2024-01-01"
 
+[env.production]
+pages_build_output_dir = "src"
+
+[env.staging]
+name = "chroniclesync-pages-staging"
 pages_build_output_dir = "src"


### PR DESCRIPTION
This PR adds proper staging environment configuration for Pages deployment.

Changes:
- Added staging environment configuration in pages/wrangler.toml
- Set staging project name to chroniclesync-pages-staging
- Separated production and staging configurations

This change will allow proper staging deployments with the correct project name.