### PR TITLE
fix: Update API_URL to handle both domains

### DIFF
--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -1,6 +1,9 @@
 import { DB } from './db';
 
-const API_URL = 'https://chroniclesync-worker.posix4e.workers.dev';
+// Use the worker URL directly since DNS is not yet configured
+const API_URL = window.location.hostname === 'chroniclesync.xyz' 
+  ? 'https://chroniclesync-worker.posix4e.workers.dev'
+  : window.location.origin;
 const db = new DB();
 
 async function initializeClient() {


### PR DESCRIPTION
This PR fixes the CORS issues by ensuring the frontend uses the correct API URL:

- When accessing from chroniclesync.xyz, it uses the worker URL
- When accessing directly from the worker URL, it uses that URL
- This allows the app to work in both environments until DNS is configured

Changes:
- Updated `API_URL` in `pages/src/js/main.js` to dynamically use the correct URL based on the current domain
- Added comments explaining the URL selection logic

After this is merged and deployed, users will be able to:
1. Access the app at https://chroniclesync.xyz/ and it will correctly communicate with the worker
2. Or access the app directly at https://chroniclesync-worker.posix4e.workers.dev/

The CORS errors will be resolved in both cases because:
1. The worker has the correct CORS headers (added in previous PR)
2. The API requests will now go to the correct URL