### PR TITLE
feat: Update to use custom domains with Cloudflare Pages preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ A simple application that demonstrates synchronization between IndexedDB and Clo
 │   └── wrangler.toml  # Worker configuration
 ```
 
+## Environments
+
+The application supports two environments:
+
+### Production
+- Frontend: https://chroniclesync.xyz
+- API: https://api.chroniclesync.xyz
+- Uses production D1 database and R2 bucket
+- Deployed when changes are merged to main branch
+
+### Staging
+- Frontend: https://staging.chroniclesync.xyz
+- API: https://api-staging.chroniclesync.xyz
+- Uses separate staging D1 database and R2 bucket
+- Used for testing changes before production deployment
+
 ## Components
 
 ### Worker
@@ -53,7 +69,11 @@ npx wrangler r2 bucket create sync-storage
 
 3. Update the `worker/wrangler.toml` with your D1 database ID
 
-4. Update the `API_URL` in `pages/src/js/main.js` with your worker's URL
+4. Configure custom domains in your DNS settings:
+   - Production API: `api.chroniclesync.xyz`
+   - Staging API: `api-staging.chroniclesync.xyz`
+   - Frontend Production: `chroniclesync.xyz`
+   - Frontend Staging: `staging.chroniclesync.xyz`
 
 ## Repository Secrets
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ The application supports two environments:
 - Uses production D1 database and R2 bucket
 - Deployed when changes are merged to main branch
 
-### Staging/Preview
-- Frontend: Automatically deployed to `*.pages.dev` by Cloudflare Pages
+### Preview (Staging)
+- Frontend: Automatically deployed to `chroniclesync.pages.dev` by Cloudflare Pages
 - API: https://api-staging.chroniclesync.xyz
 - Uses separate staging D1 database and R2 bucket
-- Preview deployments created automatically for each branch
-- Used for testing changes before production deployment
+- Preview deployments are created automatically for each branch
+- Branch previews are available at `[branch-name].chroniclesync.pages.dev`
+- The preview deployment serves as the staging environment
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ The application supports two environments:
 - Uses production D1 database and R2 bucket
 - Deployed when changes are merged to main branch
 
-### Staging
-- Frontend: https://staging.chroniclesync.xyz
+### Staging/Preview
+- Frontend: Automatically deployed to `*.pages.dev` by Cloudflare Pages
 - API: https://api-staging.chroniclesync.xyz
 - Uses separate staging D1 database and R2 bucket
+- Preview deployments created automatically for each branch
 - Used for testing changes before production deployment
 
 ## Components

--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -9,8 +9,8 @@ const API_URL = (() => {
     return 'https://api.chroniclesync.xyz';
   }
   
-  // Cloudflare Pages preview deployments
-  if (hostname.includes('.pages.dev')) {
+  // Preview deployment (staging) in Cloudflare Pages
+  if (hostname.endsWith('chroniclesync.pages.dev')) {
     return 'https://api-staging.chroniclesync.xyz';
   }
   

--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -1,6 +1,9 @@
 import { DB } from './db';
 
-const API_URL = 'https://chroniclesync-worker.posix4e.workers.dev';
+// Use the worker URL directly since DNS is not yet configured
+const API_URL = window.location.hostname === 'chroniclesync.xyz' 
+  ? 'https://chroniclesync-worker.posix4e.workers.dev'
+  : window.location.origin;
 const db = new DB();
 
 async function initializeClient() {

--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -1,9 +1,27 @@
 import { DB } from './db';
 
-// Use environment-specific API URLs
-const API_URL = window.location.hostname === 'staging.chroniclesync.xyz'
-  ? 'https://api-staging.chroniclesync.xyz'
-  : 'https://api.chroniclesync.xyz';
+// Determine API URL based on the current hostname
+const API_URL = (() => {
+  const hostname = window.location.hostname;
+  
+  // Production domain
+  if (hostname === 'chroniclesync.xyz') {
+    return 'https://api.chroniclesync.xyz';
+  }
+  
+  // Cloudflare Pages preview deployments
+  if (hostname.includes('.pages.dev')) {
+    return 'https://api-staging.chroniclesync.xyz';
+  }
+  
+  // Local development
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return 'http://localhost:8787';
+  }
+  
+  // Default to production API
+  return 'https://api.chroniclesync.xyz';
+})();
 const db = new DB();
 
 async function initializeClient() {

--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -1,9 +1,9 @@
 import { DB } from './db';
 
-// Use the worker URL directly since DNS is not yet configured
-const API_URL = window.location.hostname === 'chroniclesync.xyz' 
-  ? 'https://chroniclesync-worker.posix4e.workers.dev'
-  : window.location.origin;
+// Use environment-specific API URLs
+const API_URL = window.location.hostname === 'staging.chroniclesync.xyz'
+  ? 'https://api-staging.chroniclesync.xyz'
+  : 'https://api.chroniclesync.xyz';
 const db = new DB();
 
 async function initializeClient() {


### PR DESCRIPTION
This PR updates the application to use custom domains for the API and integrates with Cloudflare Pages preview deployments:

### API Endpoints
- Production API: api.chroniclesync.xyz
- Staging API: api-staging.chroniclesync.xyz

### Frontend URLs
- Production: chroniclesync.xyz
- Staging/Preview: chroniclesync.pages.dev
- Branch Previews: [branch-name].chroniclesync.pages.dev
- Local Development: localhost:5173

### Changes
1. Update API_URL in frontend code to handle multiple environments:
   - Production domain (chroniclesync.xyz)
   - Cloudflare Pages preview deployment (chroniclesync.pages.dev)
   - Branch preview deployments ([branch].chroniclesync.pages.dev)
   - Local development
2. Add environment documentation to README
3. Update setup instructions for custom domains
4. Add support for automatic environment detection

The wrangler.toml file already has the correct custom domain configuration.

### After merging
1. Deploy the worker to both environments:
```bash
# Deploy production
cd worker
wrangler deploy --env production

# Deploy staging
wrangler deploy --env staging
```

2. Configure DNS records:
   - api.chroniclesync.xyz -> Production worker
   - api-staging.chroniclesync.xyz -> Staging worker
   - chroniclesync.xyz -> Production frontend

The frontend preview deployments will be handled automatically by Cloudflare Pages, with:
- Main branch -> chroniclesync.pages.dev (staging)
- Other branches -> [branch-name].chroniclesync.pages.dev