### PR TITLE
fix: Add CORS headers and improve database configuration

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/preset-env": "^7.22.20",
         "@cloudflare/workers-types": "^4.20230914.0",
         "babel-jest": "^29.7.0",
-        "eslint": "^8.51.0",
+        "eslint": "^8.57.1",
         "jest": "^29.7.0",
         "jest-environment-miniflare": "^2.14.1",
         "wrangler": "^3.101.0"

--- a/worker/package.json
+++ b/worker/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.22.20",
     "@cloudflare/workers-types": "^4.20230914.0",
     "babel-jest": "^29.7.0",
-    "eslint": "^8.51.0",
+    "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "jest-environment-miniflare": "^2.14.1",
     "wrangler": "^3.101.0"

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -71,6 +71,27 @@ export default {
 
   async handleAdminClients(request, env) {
     try {
+      // Check if table exists
+      try {
+        const tableCheck = await env.DB.prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='clients'"
+        ).all();
+        console.log('Table check result:', tableCheck);
+        
+        if (!tableCheck.results || tableCheck.results.length === 0) {
+          return new Response('Database table not found', { 
+            status: 500,
+            headers: this.corsHeaders()
+          });
+        }
+      } catch (dbError) {
+        console.error('Error checking table:', dbError);
+        return new Response('Database error: ' + dbError.message, { 
+          status: 500,
+          headers: this.corsHeaders()
+        });
+      }
+      
       const clients = await env.DB.prepare(
         'SELECT client_id, last_sync, data_size FROM clients'
       ).all();
@@ -99,7 +120,10 @@ export default {
       return Response.json(stats, { headers: this.corsHeaders() });
     } catch (e) {
       console.error('Error getting client list:', e);
-      return new Response('Internal server error', { status: 500 });
+      return new Response('Internal server error', { 
+        status: 500,
+        headers: this.corsHeaders()
+      });
     }
   },
 
@@ -127,7 +151,10 @@ export default {
         });
       } catch (e) {
         console.error('Error deleting client:', e);
-        return new Response('Internal server error', { status: 500 });
+        return new Response('Internal server error', { 
+          status: 500,
+          headers: this.corsHeaders()
+        });
       }
     }
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -74,7 +74,7 @@ export default {
       // Check if table exists
       try {
         const tableCheck = await env.DB.prepare(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name='clients'"
+          'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=\'clients\''
         ).all();
         console.log('Table check result:', tableCheck);
         

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -6,10 +6,16 @@ describe('Worker API', () => {
   beforeEach(() => {
     env = {
       DB: {
-        prepare: jest.fn().mockReturnThis(),
-        bind: jest.fn().mockReturnThis(),
-        run: jest.fn().mockResolvedValue({}),
-        all: jest.fn().mockResolvedValue({ results: [] }),
+        prepare: jest.fn().mockImplementation((query) => ({
+          bind: jest.fn().mockReturnThis(),
+          run: jest.fn().mockResolvedValue({}),
+          all: jest.fn().mockImplementation(() => {
+            if (query.includes('sqlite_master')) {
+              return Promise.resolve({ results: [{ name: 'clients' }] });
+            }
+            return Promise.resolve({ results: [] });
+          }),
+        })),
       },
       STORAGE: {
         get: jest.fn().mockResolvedValue(null),

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -10,7 +10,7 @@ routes = [
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "sync_db"
-database_id = "your-d1-database-id"
+database_id = "2249bfac71db40ad8b7de370021d14fc"
 
 [[env.production.r2_buckets]]
 binding = "STORAGE"
@@ -26,7 +26,7 @@ routes = [
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "sync_db_staging"
-database_id = "7cfdcb13-18ba-4a6d-85c3-0c75466debfc"
+database_id = "3eb2f396c7e749d7a993ce86d90875b2"
 
 [[env.staging.r2_buckets]]
 binding = "STORAGE"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -9,7 +9,7 @@ routes = [
 
 [[env.production.d1_databases]]
 binding = "DB"
-database_name = "sync_db"
+database_name = "production"
 database_id = "2249bfac71db40ad8b7de370021d14fc"
 
 [[env.production.r2_buckets]]
@@ -25,7 +25,7 @@ routes = [
 
 [[env.staging.d1_databases]]
 binding = "DB"
-database_name = "sync_db_staging"
+database_name = "staging"
 database_id = "3eb2f396c7e749d7a993ce86d90875b2"
 
 [[env.staging.r2_buckets]]


### PR DESCRIPTION
This PR includes several improvements:

1. Fixes CORS headers in error responses
2. Adds better database error logging
3. Updates database IDs for staging and production
4. Adds table existence check

TODO:
- [ ] Move database IDs to GitHub secrets
- [ ] Update wrangler.toml to use environment variables

Database IDs should be moved to GitHub secrets for better security and environment management. After this PR is merged, we should:

1. Create the following GitHub secrets:
   - `CF_PROD_DB_ID`: 2249bfac71db40ad8b7de370021d14fc
   - `CF_STAGING_DB_ID`: 3eb2f396c7e749d7a993ce86d90875b2

2. Update wrangler.toml to use these secrets:
```toml
database_id = "${CF_PROD_DB_ID}" # for production
database_id = "${CF_STAGING_DB_ID}" # for staging
```