### PR TITLE
fix: Replace inline onclick handlers with event listeners

### DIFF
--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -117,15 +117,24 @@ async function refreshStats() {
 
     stats.forEach(client => {
       const row = document.createElement('tr');
+      const deleteBtn = document.createElement('button');
+      deleteBtn.textContent = 'Delete';
+      deleteBtn.addEventListener('click', () => deleteClient(client.clientId));
+
+      const viewBtn = document.createElement('button');
+      viewBtn.textContent = 'View Data';
+      viewBtn.addEventListener('click', () => viewClientData(client.clientId));
+
+      const actionsCell = document.createElement('td');
+      actionsCell.appendChild(deleteBtn);
+      actionsCell.appendChild(viewBtn);
+
       row.innerHTML = `
                 <td>${client.clientId}</td>
                 <td>${new Date(client.lastSync).toLocaleString()}</td>
                 <td>${formatBytes(client.dataSize)}</td>
-                <td>
-                    <button onclick="deleteClient('${client.clientId}')">Delete</button>
-                    <button onclick="viewClientData('${client.clientId}')">View Data</button>
-                </td>
             `;
+      row.appendChild(actionsCell);
       tbody.appendChild(row);
     });
   } catch (error) {


### PR DESCRIPTION
This PR fixes Content Security Policy (CSP) violations by replacing inline onclick handlers with proper event listeners.

Changes made:
- Removed inline onclick attributes from buttons in the stats table
- Added proper event listeners using addEventListener
- Maintained existing functionality while making the code CSP-compliant

This change will help prevent CSP warnings and follows best practices for event handling in JavaScript.