### PR TITLE
Enable Cloudflare worker logs by default

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,7 @@
 name = "chroniclesync-worker"
 main = "src/index.js"
 compatibility_date = "2024-01-01"
+log_level = "debug"
 
 [env.production]
 routes = [


### PR DESCRIPTION
This PR enables debug-level logging for Cloudflare workers by default by adding `log_level = "debug"` to the worker configuration. This will help with debugging and monitoring in both development and production environments.