### PR TITLE
Enable Cloudflare Worker logs

### DIFF
--- a/webworker/wrangler.toml
+++ b/webworker/wrangler.toml
@@ -1,0 +1,2 @@
+[observability.logs]
+enabled = true


### PR DESCRIPTION
Added wrangler.toml configuration to enable logging for Cloudflare Workers.