### PR TITLE
Simplify DB_ID secrets usage in Cloudflare

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,7 +11,7 @@ routes = [
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "production"
-database_id = "${CF_PROD_DB_ID}"
+database_id = "DB_ID"
 
 [[env.production.r2_buckets]]
 binding = "STORAGE"
@@ -27,7 +27,7 @@ routes = [
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "staging"
-database_id = "${CF_STAGING_DB_ID}"
+database_id = "DB_ID"
 
 [[env.staging.r2_buckets]]
 binding = "STORAGE"


### PR DESCRIPTION
This PR simplifies the usage of DB_ID secrets in the Cloudflare configuration:

- Removes direct usage of CF_PROD_DB_ID and CF_STAGING_DB_ID from wrangler.toml
- Uses Cloudflare secrets for DB_ID instead
- Each environment (production/staging) will manage its own DB_ID secret through Cloudflare

After merging this PR, you will need to:
1. Set up a Cloudflare secret named "DB_ID" for production with the production database ID
2. Set up a Cloudflare secret named "DB_ID" for staging with the staging database ID