### PR TITLE
Consolidate database setup files into worker directory

### DIFF
--- a/worker/setup_databases.sh
+++ b/worker/setup_databases.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Setting up tables in staging database..." 
+npx wrangler d1 execute staging --config wrangler.setup.toml --file=setup_tables.sql --remote
+
+echo "Setting up tables in production database..."
+npx wrangler d1 execute production --config wrangler.setup.toml --file=setup_tables.sql --remote
+
+echo "Done! Tables have been created in both databases."

--- a/worker/setup_tables.sql
+++ b/worker/setup_tables.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS clients;
+CREATE TABLE clients (
+  client_id TEXT PRIMARY KEY,
+  last_sync DATETIME,
+  data_size INTEGER
+);


### PR DESCRIPTION
This PR consolidates the database setup infrastructure into the worker directory:

- Moved `setup_tables.sql` to worker directory
- Moved `setup_databases.sh` to worker directory

This consolidation makes sense since the worker is responsible for data synchronization and uses D1 for metadata storage.