### PR TITLE
Add KV namespace bindings to wrangler.toml

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -14,6 +14,10 @@ routes = [
 binding = "STORAGE"
 bucket_name = "sync-storage"
 
+[[env.production.kv_namespaces]]
+binding = "METADATA"
+id = "metadata-kv"
+
 [env.staging]
 name = "chroniclesync-worker-staging"
 routes = [
@@ -23,3 +27,7 @@ routes = [
 [[env.staging.r2_buckets]]
 binding = "STORAGE"
 bucket_name = "sync-storage-staging"
+
+[[env.staging.kv_namespaces]]
+binding = "METADATA"
+id = "metadata-kv-staging"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -16,7 +16,7 @@ bucket_name = "sync-storage"
 
 [[env.production.kv_namespaces]]
 binding = "METADATA"
-id = "metadata-kv"
+id = "885fc6a560ab45e7bfd3b89252f89f2d"
 
 [env.staging]
 name = "chroniclesync-worker-staging"
@@ -30,4 +30,4 @@ bucket_name = "sync-storage-staging"
 
 [[env.staging.kv_namespaces]]
 binding = "METADATA"
-id = "metadata-kv-staging"
+id = "6af335e197d04907ae89366c50ada619"


### PR DESCRIPTION
This PR adds the required KV namespace bindings to wrangler.toml to fix the `Cannot read properties of undefined (reading put)` error.

Changes:
- Add METADATA KV namespace binding for production
- Add METADATA KV namespace binding for staging
- Use separate KV namespaces for staging and production

After merging this PR, you will need to:
1. Create the KV namespaces in Cloudflare:
```bash
wrangler kv:namespace create metadata-kv
wrangler kv:namespace create metadata-kv-staging
```
2. Update the namespace IDs in wrangler.toml with the IDs from step 1
3. Deploy the worker to apply the changes