### PR TITLE
Add Content Security Policy (CSP) headers

### DIFF
--- a/pages/src/_headers
+++ b/pages/src/_headers
@@ -1,0 +1,5 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.chroniclesync.xyz https://api-staging.chroniclesync.xyz
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
This PR adds Content Security Policy (CSP) and other security headers to the Pages deployment to fix CSP issues on chroniclesync.xyz.

Changes:
- Added `_headers` file with CSP configuration that:
  - Allows scripts from same origin and inline scripts
  - Allows styles from same origin and inline styles
  - Allows connections to API endpoints
  - Sets default-src to self
- Added additional security headers:
  - X-Frame-Options
  - X-Content-Type-Options
  - Referrer-Policy

These changes will help secure the application while maintaining all current functionality.