### PR TITLE
fix: properly handle ES modules for health check functionality

### DIFF
--- a/pages/src/index.html
+++ b/pages/src/index.html
@@ -123,7 +123,14 @@
         </style>
     </div>
 
-    <script src="js/db.js"></script>
-    <script src="js/main.js"></script>
+    <script type="module">
+        import { initializeClient, saveData, syncData, loginAdmin, checkHealth } from './js/main.js';
+        // Make functions available globally for onclick handlers
+        window.initializeClient = initializeClient;
+        window.saveData = saveData;
+        window.syncData = syncData;
+        window.loginAdmin = loginAdmin;
+        window.checkHealth = checkHealth;
+    </script>
 </body>
 </html>

--- a/pages/src/js/main.js
+++ b/pages/src/js/main.js
@@ -215,12 +215,7 @@ async function checkHealth() {
   }
 }
 
-// Make functions available globally for onclick handlers
-window.checkHealth = checkHealth;
-window.initializeClient = initializeClient;
-window.saveData = saveData;
-window.syncData = syncData;
-window.loginAdmin = loginAdmin;
+// Functions are exported and made global in the HTML file
 
 function formatBytes(bytes) {
   if (bytes === 0) return '0 Bytes';


### PR DESCRIPTION
This PR fixes the health check functionality by properly handling ES modules:

1. Updated index.html to:
   - Use `type="module"` for script loading
   - Import functions explicitly from main.js
   - Assign functions to window object in a single place

2. Cleaned up main.js by:
   - Removing redundant global assignments
   - Keeping the code DRY by handling global assignments in HTML

This fixes the "checkHealth is not defined" error in production by ensuring proper module loading and global function availability.