### PR TITLE
docs: remove non-existent documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ await deleteClient('client-123');
 
 ## Support
 
-- Documentation: https://docs.chroniclesync.xyz
-- Issues: https://github.com/posix4e/chroniclesync/issues
-- Email: support@chroniclesync.xyz
+For help and bug reports, please:
+- Open an issue: https://github.com/posix4e/chroniclesync/issues
+- See the [DEVELOPMENT.md](DEVELOPMENT.md) file for technical details
 
 ## License
 


### PR DESCRIPTION
This PR removes references to non-existent documentation resources:

- Removed link to docs.chroniclesync.xyz which does not exist
- Removed non-existent support email
- Added link to DEVELOPMENT.md for technical documentation
- Kept GitHub Issues as the main support channel