### PR TITLE
Optimize GitHub Actions workflow by combining deploy jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,10 +26,7 @@ jobs:
           
       - name: Install and Test
         working-directory: ${{ matrix.project }}
-        run: |
-          npm ci
-          npm run lint
-          npm run test:coverage
+        run: npm ci && npm run lint && npm run test:coverage
 
   deploy-pages:
     needs: test
@@ -50,13 +47,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npm ci
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            npm run deploy -- --branch main
-          else
-            npm run deploy -- --branch ${{ github.head_ref }}
-          fi
+        run: npm ci && if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --branch main; else npm run deploy -- --branch ${{ github.head_ref }}; fi
 
   deploy-worker:
     needs: test
@@ -77,10 +68,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npm ci
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            npm run deploy
-          else
-            npm run deploy -- --env staging
-          fi
+        run: npm ci && if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy; else npm run deploy -- --env staging; fi

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{ matrix.project }}
         run: npm ci && npm run lint && npm run test:coverage
 
-  deploy-pages:
+  deploy:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main'
@@ -40,7 +40,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: pages/package-lock.json
+          cache-dependency-path: |
+            pages/package-lock.json
+            worker/package-lock.json
 
       - name: Deploy Pages
         working-directory: pages
@@ -48,20 +50,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npm ci && if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --branch main; else npm run deploy -- --branch ${{ github.head_ref }}; fi
-
-  deploy-worker:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main'
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          cache-dependency-path: worker/package-lock.json
 
       - name: Deploy Worker
         working-directory: worker


### PR DESCRIPTION
This PR optimizes the GitHub Actions workflow by combining the deployment jobs:

- Combined `deploy-pages` and `deploy-worker` into a single `deploy` job
- Shared `setup-node` step with both package-lock.json files
- Maintained same functionality with less duplication
- Improved efficiency by reusing Node.js setup

No functional changes, just better workflow organization.