### PR TITLE
Fix JavaScript MIME type and module paths

### DIFF
--- a/pages/src/_headers
+++ b/pages/src/_headers
@@ -3,3 +3,9 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
+
+/*.js
+  Content-Type: application/javascript
+
+/js/*.js
+  Content-Type: application/javascript

--- a/pages/src/index.html
+++ b/pages/src/index.html
@@ -124,7 +124,7 @@
     </div>
 
     <script type="module">
-        import { initializeClient, saveData, syncData, loginAdmin, checkHealth, refreshStats } from './js/main.js';
+        import { initializeClient, saveData, syncData, loginAdmin, checkHealth, refreshStats } from '/js/main.js';
         // Make functions available globally for onclick handlers
         window.initializeClient = initializeClient;
         window.saveData = saveData;


### PR DESCRIPTION
This PR fixes the MIME type error for JavaScript modules by:

1. Adding proper Content-Type headers in _headers file:
```
/*.js
  Content-Type: application/javascript

/js/*.js
  Content-Type: application/javascript
```

2. Using absolute paths for module imports:
```javascript
import { ... } from "/js/main.js";
```

These changes ensure that:
- JavaScript files are served with the correct MIME type for ES modules
- Module paths are consistent across different pages
- Content-Security-Policy headers are maintained

All tests are passing. This should resolve the MIME type errors when accessing https://chroniclesync.xyz/