### PR TITLE
Make worker deployment environment explicit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,4 +46,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy; else npm run deploy -- --env staging; fi
+        run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --env production; else npm run deploy -- --env staging; fi


### PR DESCRIPTION
This PR explicitly specifies the environment when deploying the worker in GitHub Actions.

Changes:
- Modified the Deploy Worker step to use `--env production` when deploying from the main branch
- This ensures we are explicitly using the production environment configuration from wrangler.toml
- Makes the deployment process more clear and prevents any ambiguity about which environment is being used