### PR TITLE
Remove coverage requirement for pages component

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test Pages
         working-directory: pages
-        run: npm ci && npm run lint && npm run test:coverage
+        run: npm ci && npm run lint && npm run test
 
       - name: Test Worker
         working-directory: worker


### PR DESCRIPTION
This PR removes the coverage requirement for the pages component while keeping it for the worker component.

Changes:
- Modified CI/CD workflow to use `npm run test` instead of `npm run test:coverage` for pages testing