### PR TITLE
Add seconds to beta release tag and title for uniqueness

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,8 +117,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BETA_TAG="beta-$(date +%Y%m%d)"
-          BETA_TITLE="Beta Release $(date +%Y-%m-%d)"
+          BETA_TAG="beta-$(date +%Y%m%d-%H%M%S)"
+          BETA_TITLE="Beta Release $(date +%Y-%m-%d %H:%M:%S)"
           gh release create "$BETA_TAG" pages/chroniclesync-*.zip \
             --title "$BETA_TITLE" \
             --notes "Beta release from main branch


### PR DESCRIPTION
This PR adds seconds to the beta release tag and title to ensure each release has a unique identifier. This will prevent issues with old releases not being deleted when merging to main.

Changes:
- Modified beta release tag format from `beta-YYYYMMDD` to `beta-YYYYMMDD-HHMMSS`
- Modified beta release title to include time in format `YYYY-MM-DD HH:MM:SS`