### PR TITLE
Fix beta release title date format

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,8 +117,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BETA_TAG="beta-$(date +%Y%m%d)"
-          BETA_TITLE="Beta Release $(date +%Y-%m-%d)"
+          BETA_TAG="beta-$(date +%Y%m%d-%H%M%S)"
+          BETA_TITLE="Beta Release $(date +%Y-%m-%d %H:%M:%S)"
           gh release create "$BETA_TAG" pages/chroniclesync-*.zip \
             --title "$BETA_TITLE" \
             --notes "Beta release from main branch

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -118,7 +118,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BETA_TAG="beta-$(date +%Y%m%d-%H%M%S)"
-          BETA_TITLE="Beta Release $(date +%Y-%m-%d %H:%M:%S)"
+          BETA_TITLE="Beta Release $(date '+%Y-%m-%d %H:%M:%S')"
           gh release create "$BETA_TAG" pages/chroniclesync-*.zip \
             --title "$BETA_TITLE" \
             --notes "Beta release from main branch


### PR DESCRIPTION
Fixed the date format in the beta release title by properly quoting the date format string. This fixes the error:

```
date: extra operand %H:%M:%S
```

The fix adds single quotes around the date format string for the title:
`date '%Y-%m-%d %H:%M:%S'`