### PR TITLE
Fix beta release deletion by using exact pattern matching

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,7 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Delete old beta releases and their tags
-          for tag in $(gh release list | grep "beta-" | cut -f1); do
+          for tag in $(gh release list --limit 100 | grep -o 'beta-[0-9]\{8\}-[0-9]\{6\}'); do
             echo "Deleting release and tag: $tag"
             gh release delete "$tag" -y || true
             git tag -d "$tag" 2>/dev/null || true


### PR DESCRIPTION
Fixed the beta release deletion command to properly identify and delete old beta releases.

Changes:
- Added `--limit 100` to ensure we get enough releases in the list
- Changed the grep pattern to use `-o` to only output the matching part
- Added a specific pattern `beta-[0-9]{8}-[0-9]{6}` to match our beta tag format exactly

This will prevent the command from trying to delete non-existent releases when the grep command incorrectly splits the release title.