### PR TITLE
Fix browser polyfill loading order in popup

### DIFF
--- a/pages/src/extension/popup.js
+++ b/pages/src/extension/popup.js
@@ -1,17 +1,20 @@
-function getBrowser() {
-  if (typeof browser !== 'undefined') return browser;
-  if (typeof chrome !== 'undefined') return chrome;
-  if (typeof window !== 'undefined' && window.safari) return window.safari;
-  throw new Error('Unsupported browser');
-}
-
-document.getElementById('openDashboard').addEventListener('click', () => {
-  const browser = getBrowser();
-  const url = 'http://localhost:3000';
-  
-  if (browser === window.safari) {
-    window.open(url, '_blank');
-  } else {
-    browser.tabs.create({ url });
+// Wait for DOM and browser polyfill to be ready
+document.addEventListener('DOMContentLoaded', () => {
+  function getBrowser() {
+    if (typeof browser !== 'undefined') return browser;
+    if (typeof chrome !== 'undefined') return chrome;
+    if (typeof window !== 'undefined' && window.safari) return window.safari;
+    throw new Error('Unsupported browser');
   }
+
+  document.getElementById('openDashboard').addEventListener('click', () => {
+    const browser = getBrowser();
+    const url = 'http://localhost:3000';
+    
+    if (browser === window.safari) {
+      window.open(url, '_blank');
+    } else {
+      browser.tabs.create({ url });
+    }
+  });
 });


### PR DESCRIPTION
Fixed the "Cannot access browser before initialization" error by:

1. Wrapping the popup.js code in a DOMContentLoaded event listener
2. This ensures that both the DOM and the browser-polyfill.js are loaded before we try to use them

The error occurred because popup.js was trying to access the browser object before browser-polyfill.js had a chance to initialize it.