### PR TITLE
Add KV-based admin password management

### DIFF
--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -257,7 +257,7 @@ describe('Worker API', () => {
     it('handles errors in client info', async () => {
       const originalGet = env.METADATA.get;
       let getCallCount = 0;
-      env.METADATA.get = (key) => {
+      env.METADATA.get = (_key) => {
         getCallCount++;
         // First call is for password validation
         if (getCallCount === 1) {

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -256,7 +256,16 @@ describe('Worker API', () => {
 
     it('handles errors in client info', async () => {
       const originalGet = env.METADATA.get;
-      env.METADATA.get = () => { throw new Error('KV error'); };
+      let getCallCount = 0;
+      env.METADATA.get = (key) => {
+        getCallCount++;
+        // First call is for password validation
+        if (getCallCount === 1) {
+          return 'francesisthebest';
+        }
+        // Subsequent calls should throw the error
+        throw new Error('KV error');
+      };
 
       const resp = await makeRequest('/admin/clients', {
         headers: {
@@ -660,6 +669,85 @@ describe('Worker API', () => {
       expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
       expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
       expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
+    });
+  });
+
+  describe('Password Management', () => {
+    let originalGet;
+    let originalPut;
+
+    beforeEach(() => {
+      originalGet = env.METADATA.get;
+      originalPut = env.METADATA.put;
+    });
+
+    afterEach(() => {
+      env.METADATA.get = originalGet;
+      env.METADATA.put = originalPut;
+    });
+
+    it('changes admin password successfully', async () => {
+      const resp = await makeRequest('/admin/password', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer francesisthebest',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ newPassword: 'newpassword123' })
+      });
+      expect(resp.status).toBe(200);
+      const data = await resp.json();
+      expect(data.message).toBe('Password updated successfully');
+
+      // Verify old password no longer works
+      const oldAuthResp = await makeRequest('/admin/clients', {
+        headers: {
+          'Authorization': 'Bearer francesisthebest'
+        }
+      });
+      expect(oldAuthResp.status).toBe(401);
+
+      // Verify new password works
+      const newAuthResp = await makeRequest('/admin/clients', {
+        headers: {
+          'Authorization': 'Bearer newpassword123'
+        }
+      });
+      expect(newAuthResp.status).toBe(200);
+    });
+
+    it('rejects invalid password changes', async () => {
+      const resp = await makeRequest('/admin/password', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer francesisthebest',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ newPassword: 'short' })
+      });
+      expect(resp.status).toBe(400);
+      const data = await resp.json();
+      expect(data.error).toContain('must be at least 8 characters');
+    });
+
+    it('requires authentication for password change', async () => {
+      const resp = await makeRequest('/admin/password', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ newPassword: 'newpassword123' })
+      });
+      expect(resp.status).toBe(401);
+    });
+
+    it('requires POST method for password change', async () => {
+      const resp = await makeRequest('/admin/password', {
+        headers: {
+          'Authorization': 'Bearer francesisthebest'
+        }
+      });
+      expect(resp.status).toBe(405);
     });
   });
 });

--- a/worker/src/services/metadata.js
+++ b/worker/src/services/metadata.js
@@ -4,6 +4,8 @@ class MetadataService {
       throw new Error('METADATA KV binding is required');
     }
     this.kv = env.METADATA;
+    this.ADMIN_PASSWORD_KEY = '_admin_password';
+    this.DEFAULT_PASSWORD = 'francesisthebest';
   }
 
   async get(clientId) {
@@ -32,6 +34,23 @@ class MetadataService {
   async validateMetadata(metadata) {
     if (!metadata || !metadata.lastSync) return false;
     return !isNaN(new Date(metadata.lastSync).getTime());
+  }
+
+  async getAdminPassword() {
+    const storedPassword = await this.kv.get(this.ADMIN_PASSWORD_KEY);
+    return storedPassword || this.DEFAULT_PASSWORD;
+  }
+
+  async setAdminPassword(newPassword) {
+    if (!newPassword || typeof newPassword !== 'string' || newPassword.length < 8) {
+      throw new Error('Password must be at least 8 characters long');
+    }
+    await this.kv.put(this.ADMIN_PASSWORD_KEY, newPassword);
+  }
+
+  async validateAdminPassword(password) {
+    const currentPassword = await this.getAdminPassword();
+    return password === currentPassword;
   }
 }
 


### PR DESCRIPTION
This PR adds a new feature to manage the admin password using KV store:

- Adds password management methods to MetadataService
- Updates admin authentication to use KV-stored password
- Adds new `/admin/password` endpoint for password management
- Falls back to default password if no custom password is set
- Requires minimum password length of 8 characters

To use the new feature:
1. Initially use default password "francesisthebest"
2. Change password via POST to `/admin/password` with new password in request body
3. Use new password in Bearer token for subsequent admin requests