### PR TITLE
Add debug log artifacts for build and test processes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,43 +34,69 @@ jobs:
       - name: Install and Build Pages
         working-directory: pages
         run: |
-          echo "Installing dependencies..."
-          npm ci
-
-          echo "Running linting..."
-          npm run lint
-
-          echo "Running tests..."
-          npm run test
-
-          echo "Building web app..."
-          npm run build:web
-
-          echo "Building and packaging extensions..."
-          for BROWSER in chrome firefox safari; do
-            echo "Building $BROWSER extension..."
-            if ! BROWSER=$BROWSER npm run build:extensions; then
-              echo "::error::Failed to build $BROWSER extension"
-              echo "Build output:"
-              ls -la "dist/$BROWSER" || true
-              if [ -f "dist/$BROWSER/manifest.json" ]; then
-                echo "$BROWSER manifest:"
-                cat "dist/$BROWSER/manifest.json"
+          # Create a directory for debug logs
+          mkdir -p debug_logs
+          
+          {
+            echo "Installing dependencies..."
+            npm ci
+            
+            echo "Running linting..."
+            npm run lint
+            
+            echo "Running tests..."
+            npm run test
+            
+            echo "Building web app..."
+            npm run build:web
+            
+            echo "Building and packaging extensions..."
+            for BROWSER in chrome firefox safari; do
+              echo "Building $BROWSER extension..."
+              if ! BROWSER=$BROWSER npm run build:extensions; then
+                echo "::error::Failed to build $BROWSER extension"
+                echo "Build output:"
+                ls -la "dist/$BROWSER" || true
+                if [ -f "dist/$BROWSER/manifest.json" ]; then
+                  echo "$BROWSER manifest:"
+                  cat "dist/$BROWSER/manifest.json"
+                fi
+                exit 1
               fi
-              exit 1
-            fi
+              
+              echo "Packaging $BROWSER extension..."
+              if ! npm run "package:$BROWSER"; then
+                echo "::error::Failed to package $BROWSER extension"
+                ls -la "dist/$BROWSER" || true
+                exit 1
+              fi
+              
+              # Capture extension-specific debug info
+              echo "Capturing debug info for $BROWSER extension..."
+              {
+                echo "=== $BROWSER Extension Build Info ==="
+                echo "Directory structure:"
+                ls -R "dist/$BROWSER"
+                echo -e "\nManifest content:"
+                cat "dist/$BROWSER/manifest.json"
+              } > "debug_logs/${BROWSER}_build_info.log"
+            done
+            
+            echo "✓ Build completed successfully"
+            echo "Generated artifacts:"
+            ls -la chroniclesync-*.zip
+            
+            # Capture final build state
+            echo -e "\nFinal build directory structure:" >> debug_logs/build_summary.log
+            ls -R . >> debug_logs/build_summary.log
+          } 2>&1 | tee debug_logs/build_output.log
 
-            echo "Packaging $BROWSER extension..."
-            if ! npm run "package:$BROWSER"; then
-              echo "::error::Failed to package $BROWSER extension"
-              ls -la "dist/$BROWSER" || true
-              exit 1
-            fi
-          done
-
-          echo "✓ Build completed successfully"
-          echo "Generated artifacts:"
-          ls -la chroniclesync-*.zip
+      - name: Upload Debug Logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-debug-logs
+          path: pages/debug_logs/
+          if-no-files-found: error
 
       - name: Upload Chrome Extension Artifact
         uses: actions/upload-artifact@v3
@@ -95,7 +121,28 @@ jobs:
 
       - name: Test Worker
         working-directory: worker
-        run: npm ci && npm run lint && npm run test:coverage
+        run: |
+          mkdir -p debug_logs
+          {
+            echo "Installing dependencies..."
+            npm ci
+            
+            echo "Running linting..."
+            npm run lint
+            
+            echo "Running tests with coverage..."
+            npm run test:coverage
+            
+            echo "Capturing test coverage report..."
+            cp -r coverage debug_logs/
+          } 2>&1 | tee debug_logs/worker_output.log
+
+      - name: Upload Worker Debug Logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: worker-debug-logs
+          path: worker/debug_logs/
+          if-no-files-found: error
 
 
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,45 +34,51 @@ jobs:
       - name: Install and Build Pages
         working-directory: pages
         run: |
-          # Create a directory for debug logs
           mkdir -p debug_logs
           
+          # Redirect detailed output to log files but keep errors visible
           {
-            echo "Installing dependencies..."
-            npm ci
+            npm ci > debug_logs/npm_install.log 2>&1 || { cat debug_logs/npm_install.log; exit 1; }
+            echo "✓ Dependencies installed"
             
-            echo "Running linting..."
-            npm run lint
+            npm run lint > debug_logs/lint.log 2>&1 || { cat debug_logs/lint.log; exit 1; }
+            echo "✓ Linting passed"
             
-            echo "Running tests..."
-            npm run test
+            npm run test > debug_logs/test.log 2>&1 || { cat debug_logs/test.log; exit 1; }
+            echo "✓ Tests passed"
             
-            echo "Building web app..."
-            npm run build:web
+            npm run build:web > debug_logs/web_build.log 2>&1 || { cat debug_logs/web_build.log; exit 1; }
+            echo "✓ Web app built"
             
-            echo "Building and packaging extensions..."
             for BROWSER in chrome firefox safari; do
               echo "Building $BROWSER extension..."
-              if ! BROWSER=$BROWSER npm run build:extensions; then
+              if ! BROWSER=$BROWSER npm run build:extensions > "debug_logs/${BROWSER}_build.log" 2>&1; then
                 echo "::error::Failed to build $BROWSER extension"
-                echo "Build output:"
-                ls -la "dist/$BROWSER" || true
-                if [ -f "dist/$BROWSER/manifest.json" ]; then
-                  echo "$BROWSER manifest:"
-                  cat "dist/$BROWSER/manifest.json"
-                fi
+                cat "debug_logs/${BROWSER}_build.log"
+                {
+                  echo -e "\nBuild directory content:"
+                  ls -la "dist/$BROWSER" || true
+                  if [ -f "dist/$BROWSER/manifest.json" ]; then
+                    echo -e "\nManifest content:"
+                    cat "dist/$BROWSER/manifest.json"
+                  fi
+                } >> "debug_logs/${BROWSER}_build.log"
                 exit 1
               fi
               
               echo "Packaging $BROWSER extension..."
-              if ! npm run "package:$BROWSER"; then
+              if ! npm run "package:$BROWSER" > "debug_logs/${BROWSER}_package.log" 2>&1; then
                 echo "::error::Failed to package $BROWSER extension"
-                ls -la "dist/$BROWSER" || true
+                cat "debug_logs/${BROWSER}_package.log"
+                {
+                  echo -e "\nBuild directory content:"
+                  ls -la "dist/$BROWSER" || true
+                } >> "debug_logs/${BROWSER}_package.log"
                 exit 1
               fi
+              echo "✓ $BROWSER extension built and packaged"
               
-              # Capture extension-specific debug info
-              echo "Capturing debug info for $BROWSER extension..."
+              # Record build artifacts for debugging
               {
                 echo "=== $BROWSER Extension Build Info ==="
                 echo "Directory structure:"
@@ -82,9 +88,11 @@ jobs:
               } > "debug_logs/${BROWSER}_build_info.log"
             done
             
-            echo "✓ Build completed successfully"
-            echo "Generated artifacts:"
-            ls -la chroniclesync-*.zip
+            echo "✓ All builds completed successfully"
+            
+            # Record final artifacts list
+            echo -e "\nGenerated extension packages:" > debug_logs/artifacts_list.log
+            ls -la chroniclesync-*.zip >> debug_logs/artifacts_list.log
             
             # Capture final build state
             echo -e "\nFinal build directory structure:" >> debug_logs/build_summary.log
@@ -123,19 +131,20 @@ jobs:
         working-directory: worker
         run: |
           mkdir -p debug_logs
+          
+          # Redirect detailed output to log file but keep errors visible
           {
-            echo "Installing dependencies..."
-            npm ci
+            npm ci > debug_logs/worker_npm_install.log 2>&1 || { cat debug_logs/worker_npm_install.log; exit 1; }
+            echo "✓ Dependencies installed"
             
-            echo "Running linting..."
-            npm run lint
+            npm run lint > debug_logs/worker_lint.log 2>&1 || { cat debug_logs/worker_lint.log; exit 1; }
+            echo "✓ Linting passed"
             
-            echo "Running tests with coverage..."
-            npm run test:coverage
+            npm run test:coverage > debug_logs/worker_test.log 2>&1 || { cat debug_logs/worker_test.log; exit 1; }
+            echo "✓ Tests passed"
             
-            echo "Capturing test coverage report..."
             cp -r coverage debug_logs/
-          } 2>&1 | tee debug_logs/worker_output.log
+          }
 
       - name: Upload Worker Debug Logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR adds comprehensive debug logging and artifacts for both the extension build process and worker tests. Changes include:

- Capture detailed build logs for each browser extension
- Store extension build artifacts including directory structure and manifest content
- Capture worker test output and coverage reports
- Upload all debug logs as GitHub Actions artifacts

This will make it easier to diagnose build and test issues by having all debug information readily available as artifacts instead of scattered through the console output.