### PR TITLE
Fix GitHub Actions workflow by installing zip and unzip packages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y zip
+          sudo apt-get install -y zip unzip
 
       - name: Install and Build Pages
         working-directory: pages


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow by ensuring that the `zip` and `unzip` packages are installed before building the browser extensions.

Changes:
- Added `unzip` package to the system dependencies installation step

Tested:
- Successfully built all browser extensions (Chrome, Firefox, Safari) locally
- All tests are passing