### PR TITLE
Add basic authentication acceptance test

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,84 @@
+name: Acceptance Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  prepare-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      staging_url: ${{ steps.deploy-staging.outputs.url }}
+      extension_url: ${{ steps.upload-extension.outputs.artifact_url }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: |
+          npm ci
+          cd worker && npm ci
+          cd ../pages && npm ci
+
+      - name: Build Extension
+        run: npm run build
+        
+      - name: Upload Extension Artifact
+        id: upload-extension
+        uses: actions/upload-artifact@v3
+        with:
+          name: chroniclesync-extension
+          path: dist/
+          
+      - name: Deploy to Staging
+        id: deploy-staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          cd worker
+          npm run deploy -- --env staging
+          echo "url=$(wrangler whoami --env staging)" >> $GITHUB_OUTPUT
+
+  run-acceptance-tests:
+    needs: prepare-environment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: |
+          cd worker && npm ci
+          npx playwright install chromium
+          npx playwright install-deps chromium
+
+      - name: Download Extension Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: chroniclesync-extension
+          path: dist/
+
+      - name: Run Acceptance Tests
+        env:
+          STAGING_URL: ${{ needs.prepare-environment.outputs.staging_url }}
+        run: |
+          cd worker
+          npm run test:acceptance
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: worker/test-results/

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,14 +27,16 @@ jobs:
           cd ../pages && npm ci
 
       - name: Build Extension
-        run: npm run build
+        run: |
+          cd pages
+          npm run build:extension
         
       - name: Upload Extension Artifact
         id: upload-extension
         uses: actions/upload-artifact@v3
         with:
           name: chroniclesync-extension
-          path: dist/
+          path: pages/dist/extension/
           
       - name: Deploy to Staging
         id: deploy-staging
@@ -67,7 +69,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: chroniclesync-extension
-          path: dist/
+          path: pages/dist/extension/
 
       - name: Run Acceptance Tests
         env:

--- a/worker/jest.acceptance.config.js
+++ b/worker/jest.acceptance.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testMatch: ['**/__acceptance_tests__/**/*.test.js'],
+  testTimeout: 60000, // Longer timeout for integration tests
+  setupFilesAfterEnv: ['./jest.acceptance.setup.js'],
+  testEnvironment: 'node',
+  reporters: [
+    'default',
+    ['jest-junit', {
+      outputDirectory: 'test-results',
+      outputName: 'acceptance-junit.xml',
+    }],
+  ],
+};

--- a/worker/jest.acceptance.setup.js
+++ b/worker/jest.acceptance.setup.js
@@ -1,0 +1,12 @@
+// Increase timeout for all tests
+jest.setTimeout(60000);
+
+// Verify required environment variables
+beforeAll(() => {
+  const requiredEnvVars = ['STAGING_URL'];
+  const missing = requiredEnvVars.filter(env => !process.env[env]);
+  
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+});

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -11,11 +11,13 @@
         "@babel/core": "^7.23.0",
         "@babel/preset-env": "^7.22.20",
         "@cloudflare/workers-types": "^4.20230914.0",
+        "@playwright/test": "^1.49.1",
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.1",
         "eslint-plugin-jest": "^28.10.0",
         "jest": "^29.7.0",
         "jest-environment-miniflare": "^2.14.1",
+        "playwright": "^1.49.1",
         "wrangler": "^3.101.0"
       }
     },
@@ -4103,6 +4105,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -8477,6 +8495,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.3",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -8,6 +8,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:acceptance": "jest --config=jest.acceptance.config.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix"
   },

--- a/worker/package.json
+++ b/worker/package.json
@@ -15,11 +15,13 @@
     "@babel/core": "^7.23.0",
     "@babel/preset-env": "^7.22.20",
     "@cloudflare/workers-types": "^4.20230914.0",
+    "@playwright/test": "^1.49.1",
     "babel-jest": "^29.7.0",
     "eslint": "^8.57.1",
     "eslint-plugin-jest": "^28.10.0",
     "jest": "^29.7.0",
     "jest-environment-miniflare": "^2.14.1",
+    "playwright": "^1.49.1",
     "wrangler": "^3.101.0"
   }
 }

--- a/worker/src/__acceptance_tests__/extension.acceptance.test.js
+++ b/worker/src/__acceptance_tests__/extension.acceptance.test.js
@@ -1,6 +1,5 @@
 import { chromium } from 'playwright';
 import path from 'path';
-import fs from 'fs';
 
 describe('ChronicleSync Extension Acceptance Tests', () => {
   let browser;
@@ -10,7 +9,6 @@ describe('ChronicleSync Extension Acceptance Tests', () => {
   const extensionPath = path.resolve(__dirname, '../../../dist');
 
   beforeAll(async () => {
-    // Load the extension from the dist directory
     browser = await chromium.launch({
       headless: false,
       args: [
@@ -41,151 +39,8 @@ describe('ChronicleSync Extension Acceptance Tests', () => {
     await loginButton.click();
     
     // Wait for auth completion and verify success
-    await page.waitForSelector('[data-testid="user-profile"]');
+    await page.waitForSelector('[data-testid="user-profile"]', { timeout: 30000 });
     const profileElement = await page.$('[data-testid="user-profile"]');
     expect(profileElement).toBeTruthy();
-  });
-
-  it('should sync bookmarks successfully', async () => {
-    await page.goto(stagingUrl);
-    
-    // Trigger sync
-    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
-    await syncButton.click();
-    
-    // Wait for sync completion
-    await page.waitForSelector('[data-testid="sync-status-success"]');
-    
-    // Verify sync metadata was updated
-    const lastSyncText = await page.$eval(
-      '[data-testid="last-sync-time"]',
-      el => el.textContent
-    );
-    expect(lastSyncText).toMatch(/Last synced: /);
-  });
-
-  it('should handle offline mode gracefully', async () => {
-    await page.goto(stagingUrl);
-    
-    // Simulate offline mode
-    await context.setOffline(true);
-    
-    // Attempt sync
-    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
-    await syncButton.click();
-    
-    // Verify appropriate error message
-    const errorMessage = await page.waitForSelector('[data-testid="sync-error"]');
-    const errorText = await errorMessage.textContent();
-    expect(errorText).toContain('offline');
-  });
-
-  it('should handle large bookmark sets', async () => {
-    await page.goto(stagingUrl);
-    
-    // Create a large set of test bookmarks
-    const largeBookmarkSet = Array.from({ length: 1000 }, (_, i) => ({
-      title: `Test Bookmark ${i}`,
-      url: `https://example.com/${i}`
-    }));
-    
-    // Inject bookmarks into the page
-    await page.evaluate((bookmarks) => {
-      window.testBookmarks = bookmarks;
-    }, largeBookmarkSet);
-    
-    // Trigger sync
-    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
-    await syncButton.click();
-    
-    // Wait for sync completion and verify success
-    await page.waitForSelector('[data-testid="sync-status-success"]');
-    
-    // Verify all bookmarks were synced
-    const syncStats = await page.$eval(
-      '[data-testid="sync-stats"]',
-      el => el.textContent
-    );
-    expect(syncStats).toContain('1000');
-  });
-
-  it('should handle bookmark conflicts correctly', async () => {
-    await page.goto(stagingUrl);
-    
-    // Create conflicting bookmarks
-    const conflictingBookmark = {
-      url: 'https://example.com/conflict',
-      title: 'Conflicting Bookmark'
-    };
-    
-    // Inject bookmark data
-    await page.evaluate((bookmark) => {
-      window.testBookmark = bookmark;
-    }, conflictingBookmark);
-    
-    // Trigger sync
-    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
-    await syncButton.click();
-    
-    // Verify conflict resolution UI appears
-    const conflictDialog = await page.waitForSelector('[data-testid="conflict-dialog"]');
-    expect(conflictDialog).toBeTruthy();
-    
-    // Choose to keep local version
-    const keepLocalButton = await page.waitForSelector('[data-testid="keep-local"]');
-    await keepLocalButton.click();
-    
-    // Verify resolution was successful
-    await page.waitForSelector('[data-testid="sync-status-success"]');
-  });
-
-  it('should respect user preferences', async () => {
-    await page.goto(stagingUrl);
-    
-    // Open settings
-    const settingsButton = await page.waitForSelector('[data-testid="settings-button"]');
-    await settingsButton.click();
-    
-    // Change sync frequency to daily
-    const frequencySelect = await page.waitForSelector('[data-testid="sync-frequency"]');
-    await frequencySelect.selectOption('daily');
-    
-    // Save settings
-    const saveButton = await page.waitForSelector('[data-testid="save-settings"]');
-    await saveButton.click();
-    
-    // Verify settings were saved
-    await page.reload();
-    const savedFrequency = await page.$eval(
-      '[data-testid="sync-frequency"]',
-      el => el.value
-    );
-    expect(savedFrequency).toBe('daily');
-  });
-
-  it('should handle service interruptions gracefully', async () => {
-    await page.goto(stagingUrl);
-    
-    // Simulate service interruption by intercepting API calls
-    await context.route('**/api/**', route => {
-      return route.fulfill({
-        status: 503,
-        body: 'Service Temporarily Unavailable'
-      });
-    });
-    
-    // Attempt sync
-    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
-    await syncButton.click();
-    
-    // Verify appropriate error handling
-    const errorMessage = await page.waitForSelector('[data-testid="sync-error"]');
-    const errorText = await errorMessage.textContent();
-    expect(errorText).toContain('service');
-    expect(errorText).toContain('unavailable');
-    
-    // Verify retry mechanism
-    const retryButton = await page.waitForSelector('[data-testid="retry-button"]');
-    expect(retryButton).toBeTruthy();
   });
 });

--- a/worker/src/__acceptance_tests__/extension.acceptance.test.js
+++ b/worker/src/__acceptance_tests__/extension.acceptance.test.js
@@ -1,0 +1,191 @@
+import { chromium } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+
+describe('ChronicleSync Extension Acceptance Tests', () => {
+  let browser;
+  let context;
+  let page;
+  const stagingUrl = process.env.STAGING_URL || 'https://staging.chroniclesync.com';
+  const extensionPath = path.resolve(__dirname, '../../../dist');
+
+  beforeAll(async () => {
+    // Load the extension from the dist directory
+    browser = await chromium.launch({
+      headless: false,
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`
+      ]
+    });
+  });
+
+  beforeEach(async () => {
+    context = await browser.newContext();
+    page = await context.newPage();
+  });
+
+  afterEach(async () => {
+    await context.close();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('should successfully authenticate with the service', async () => {
+    await page.goto(stagingUrl);
+    
+    // Test authentication flow
+    const loginButton = await page.waitForSelector('[data-testid="login-button"]');
+    await loginButton.click();
+    
+    // Wait for auth completion and verify success
+    await page.waitForSelector('[data-testid="user-profile"]');
+    const profileElement = await page.$('[data-testid="user-profile"]');
+    expect(profileElement).toBeTruthy();
+  });
+
+  it('should sync bookmarks successfully', async () => {
+    await page.goto(stagingUrl);
+    
+    // Trigger sync
+    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
+    await syncButton.click();
+    
+    // Wait for sync completion
+    await page.waitForSelector('[data-testid="sync-status-success"]');
+    
+    // Verify sync metadata was updated
+    const lastSyncText = await page.$eval(
+      '[data-testid="last-sync-time"]',
+      el => el.textContent
+    );
+    expect(lastSyncText).toMatch(/Last synced: /);
+  });
+
+  it('should handle offline mode gracefully', async () => {
+    await page.goto(stagingUrl);
+    
+    // Simulate offline mode
+    await context.setOffline(true);
+    
+    // Attempt sync
+    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
+    await syncButton.click();
+    
+    // Verify appropriate error message
+    const errorMessage = await page.waitForSelector('[data-testid="sync-error"]');
+    const errorText = await errorMessage.textContent();
+    expect(errorText).toContain('offline');
+  });
+
+  it('should handle large bookmark sets', async () => {
+    await page.goto(stagingUrl);
+    
+    // Create a large set of test bookmarks
+    const largeBookmarkSet = Array.from({ length: 1000 }, (_, i) => ({
+      title: `Test Bookmark ${i}`,
+      url: `https://example.com/${i}`
+    }));
+    
+    // Inject bookmarks into the page
+    await page.evaluate((bookmarks) => {
+      window.testBookmarks = bookmarks;
+    }, largeBookmarkSet);
+    
+    // Trigger sync
+    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
+    await syncButton.click();
+    
+    // Wait for sync completion and verify success
+    await page.waitForSelector('[data-testid="sync-status-success"]');
+    
+    // Verify all bookmarks were synced
+    const syncStats = await page.$eval(
+      '[data-testid="sync-stats"]',
+      el => el.textContent
+    );
+    expect(syncStats).toContain('1000');
+  });
+
+  it('should handle bookmark conflicts correctly', async () => {
+    await page.goto(stagingUrl);
+    
+    // Create conflicting bookmarks
+    const conflictingBookmark = {
+      url: 'https://example.com/conflict',
+      title: 'Conflicting Bookmark'
+    };
+    
+    // Inject bookmark data
+    await page.evaluate((bookmark) => {
+      window.testBookmark = bookmark;
+    }, conflictingBookmark);
+    
+    // Trigger sync
+    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
+    await syncButton.click();
+    
+    // Verify conflict resolution UI appears
+    const conflictDialog = await page.waitForSelector('[data-testid="conflict-dialog"]');
+    expect(conflictDialog).toBeTruthy();
+    
+    // Choose to keep local version
+    const keepLocalButton = await page.waitForSelector('[data-testid="keep-local"]');
+    await keepLocalButton.click();
+    
+    // Verify resolution was successful
+    await page.waitForSelector('[data-testid="sync-status-success"]');
+  });
+
+  it('should respect user preferences', async () => {
+    await page.goto(stagingUrl);
+    
+    // Open settings
+    const settingsButton = await page.waitForSelector('[data-testid="settings-button"]');
+    await settingsButton.click();
+    
+    // Change sync frequency to daily
+    const frequencySelect = await page.waitForSelector('[data-testid="sync-frequency"]');
+    await frequencySelect.selectOption('daily');
+    
+    // Save settings
+    const saveButton = await page.waitForSelector('[data-testid="save-settings"]');
+    await saveButton.click();
+    
+    // Verify settings were saved
+    await page.reload();
+    const savedFrequency = await page.$eval(
+      '[data-testid="sync-frequency"]',
+      el => el.value
+    );
+    expect(savedFrequency).toBe('daily');
+  });
+
+  it('should handle service interruptions gracefully', async () => {
+    await page.goto(stagingUrl);
+    
+    // Simulate service interruption by intercepting API calls
+    await context.route('**/api/**', route => {
+      return route.fulfill({
+        status: 503,
+        body: 'Service Temporarily Unavailable'
+      });
+    });
+    
+    // Attempt sync
+    const syncButton = await page.waitForSelector('[data-testid="sync-button"]');
+    await syncButton.click();
+    
+    // Verify appropriate error handling
+    const errorMessage = await page.waitForSelector('[data-testid="sync-error"]');
+    const errorText = await errorMessage.textContent();
+    expect(errorText).toContain('service');
+    expect(errorText).toContain('unavailable');
+    
+    // Verify retry mechanism
+    const retryButton = await page.waitForSelector('[data-testid="retry-button"]');
+    expect(retryButton).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Part of #103: Implement incremental acceptance tests

This PR implements the first step in our incremental acceptance testing plan:
- Sets up basic Playwright test infrastructure
- Adds authentication test that verifies extension can load and log in
- Adds necessary dependencies

To run the tests:
1. Build the extension: `npm run build`
2. Install dependencies: `cd worker && npm install`
3. Run the test: `npm run test`

Note: The test requires access to the staging environment and expects the extension to be built in the `dist` directory.