### PR TITLE
Add e2e test for health check component

### DIFF
--- a/pages/e2e/home.spec.ts
+++ b/pages/e2e/home.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Web App', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { timeout: 30000 });
+  });
+
   test('should load the landing page', async ({ page }) => {
     // Log the URL we're testing
     console.log('Testing URL:', page.url());
@@ -27,5 +31,31 @@ test.describe('Web App', () => {
     const main = await page.locator('body').first();
     await expect(main).toBeVisible();
     console.log('Body content:', await main.textContent());
+  });
+
+  test('should interact with health check component', async ({ page }) => {
+    // Verify initial health check state
+    await expect(page.getByText('System Health')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Check Health' })).toBeVisible();
+    await expect(page.getByText('Status:')).toBeVisible();
+    await expect(page.getByText('Checking...')).toBeVisible();
+    await expect(page.getByText('Last Check:')).toBeVisible();
+    await expect(page.getByText('Never')).toBeVisible();
+
+    // Click the health check button
+    await page.getByRole('button', { name: 'Check Health' }).click();
+
+    // Wait for and verify the health status update
+    // Note: The actual status might vary depending on the system state
+    await expect(page.getByText('Status:')).toBeVisible();
+    
+    // Take a screenshot after health check
+    await page.screenshot({ 
+      path: './test-results/health-check.png',
+      fullPage: true 
+    });
+
+    // Verify the last check time is updated (should no longer show "Never")
+    await expect(page.getByText('Never')).not.toBeVisible();
   });
 });


### PR DESCRIPTION
This PR adds end-to-end tests for the health check component. Changes include:

- Refactored test structure to use `beforeEach` for common setup
- Added new test case that verifies health check component functionality
- Tests initial state, button interaction, and status updates
- Includes screenshot capture for visual verification

This is part of the effort to make tests more extensible one step at a time.