### PR TITLE
Update artifact versions and dynamic versioning

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,6 +38,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zip unzip
 
+      - name: Set Version from Git Tag
+        run: ./scripts/set-version.sh
+
       - name: Install and Build Pages
         working-directory: pages
         run: |
@@ -80,21 +83,21 @@ jobs:
           ls -la chroniclesync-*.zip
 
       - name: Upload Chrome Extension Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chroniclesync-chrome
           path: pages/chroniclesync-chrome.zip
           if-no-files-found: error
 
       - name: Upload Firefox Extension Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chroniclesync-firefox
           path: pages/chroniclesync-firefox.zip
           if-no-files-found: error
 
       - name: Upload Safari Extension Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chroniclesync-safari
           path: pages/chroniclesync-safari.zip

--- a/pages/package.json
+++ b/pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroniclesync-pages",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/pages/src/extension/manifest.safari.json
+++ b/pages/src/extension/manifest.safari.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ChronicleSync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Sync browser history across devices using ChronicleSync",
   "permissions": [
     "history",

--- a/pages/src/extension/manifest.v2.json
+++ b/pages/src/extension/manifest.v2.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ChronicleSync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Sync browser history across devices using ChronicleSync",
   "permissions": [
     "history",

--- a/pages/src/extension/manifest.v3.json
+++ b/pages/src/extension/manifest.v3.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ChronicleSync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Sync browser history across devices using ChronicleSync",
   "permissions": [
     "history",

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Get the latest version tag (excluding beta tags)
+LATEST_TAG=$(git tag -l "v*" | sort -V | tail -n1)
+VERSION=${LATEST_TAG#v}  # Remove 'v' prefix
+
+if [ -z "$VERSION" ]; then
+    echo "No version tag found"
+    exit 1
+fi
+
+echo "Setting version to $VERSION"
+
+# Update worker package.json
+sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" worker/package.json
+
+# Update pages package.json
+sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" pages/package.json
+
+# Update all manifest files
+for manifest in pages/src/extension/manifest*.json; do
+    sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" "$manifest"
+done
+
+echo "Version updated to $VERSION in all files"

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroniclesync-worker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",


### PR DESCRIPTION
This PR includes the following changes:

- Update GitHub Actions upload-artifact from v3 to v4
- Add script to dynamically set versions based on git tags
- Update CI workflow to use dynamic versioning script before build

The version numbers in package.json and manifest files will now be automatically set based on the latest git tag (currently v0.1.3).