### PR TITLE
Add and verify Xvfb support for Chrome extension testing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,6 +67,12 @@ jobs:
         run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --env production; else npm run deploy -- --env staging; fi
 
 
+      - name: Install Xvfb
+        if: github.event.pull_request.base.ref == 'main'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
       - name: Run E2E Tests Against Staging
         if: github.event.pull_request.base.ref == 'main'
         working-directory: pages
@@ -76,7 +82,7 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-          npx playwright test
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npx playwright test
 
       - name: Upload E2E Test Results
         if: always() && github.event.pull_request.base.ref == 'main'


### PR DESCRIPTION
This PR adds and verifies Xvfb support for Chrome extension testing in CI environments.

### Testing Done
- ✅ Successfully installed and configured Xvfb
- ✅ Ran extension tests with Xvfb virtual display
- ✅ All tests passed (2 tests in 5.2s)

### Technical Details
- Used `xvfb-run` with `--auto-servernum` for automatic display allocation
- Configured virtual screen with 1280x960 resolution and 24-bit color depth
- Required dependencies: xvfb, xauth

This setup is crucial for running Chrome extension tests in CI environments where no physical display is available.

### Test Command Used
```bash
xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test:extension
```

### Test Results
```
> chroniclesync-pages@1.0.0 test:extension
> playwright test e2e/extension.spec.ts

Running 2 tests using 2 workers
  2 passed (5.2s)
```

All tests passed successfully, confirming that the Xvfb setup works correctly for running Chrome extension tests in a headless environment.