### PR TITLE
Add browser history sync feature

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,23 @@
+import HistoryManager from './history.js';
+
+const generateDeviceId = () => {
+    return 'device_' + Math.random().toString(36).substr(2, 9);
+};
+
+const getOrCreateDeviceId = async () => {
+    const stored = await chrome.storage.local.get('deviceId');
+    if (stored.deviceId) {
+        return stored.deviceId;
+    }
+    const deviceId = generateDeviceId();
+    await chrome.storage.local.set({ deviceId });
+    return deviceId;
+};
+
+async function init() {
+    const deviceId = await getOrCreateDeviceId();
+    const historyManager = new HistoryManager(deviceId);
+    await historyManager.initialize();
+}
+
+init().catch(console.error);

--- a/extension/history.js
+++ b/extension/history.js
@@ -1,0 +1,53 @@
+const HISTORY_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+class HistoryManager {
+    constructor(deviceId) {
+        this.deviceId = deviceId;
+        this.lastSync = 0;
+    }
+
+    async initialize() {
+        // Start periodic sync
+        setInterval(() => this.syncHistory(), HISTORY_SYNC_INTERVAL);
+        return this.syncHistory();
+    }
+
+    async getRecentHistory(since = 0) {
+        return new Promise((resolve) => {
+            chrome.history.search({
+                text: '',
+                startTime: since,
+                maxResults: 1000
+            }, (historyItems) => {
+                resolve(historyItems.map(item => ({
+                    ...item,
+                    deviceId: this.deviceId,
+                    timestamp: Date.now()
+                })));
+            });
+        });
+    }
+
+    async syncHistory() {
+        try {
+            const historyItems = await this.getRecentHistory(this.lastSync);
+            if (historyItems.length > 0) {
+                await fetch('https://api.chroniclesync.xyz/api/history/sync', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        deviceId: this.deviceId,
+                        items: historyItems
+                    })
+                });
+                this.lastSync = Date.now();
+            }
+        } catch (error) {
+            console.error('Failed to sync history:', error);
+        }
+    }
+}
+
+export default HistoryManager;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,10 @@
   },
   "permissions": [
     "activeTab",
-    "scripting"
+    "scripting",
+    "history",
+    "storage",
+    "tabs"
   ],
   "host_permissions": [
     "http://localhost:*/*",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "chroniclesync",
+  "version": "1.0.0",
+  "description": "Browser history synchronization extension",
+  "scripts": {
+    "test": "jest tests/worker.test.js",
+    "test:e2e": "playwright test tests/extension.spec.js",
+    "start": "node worker/app.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.20.0",
+    "jest": "^27.4.7",
+    "supertest": "^6.1.6"
+  }
+}

--- a/tests/extension.spec.js
+++ b/tests/extension.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test.describe('Browser Extension Tests', () => {
+    test('should sync browser history', async ({ context, page }) => {
+        // Load the extension
+        const extensionPath = path.join(__dirname, '../extension');
+        await context.loadExtension(extensionPath);
+
+        // Visit some test pages
+        await page.goto('https://example.com');
+        await page.screenshot({ path: 'tests/screenshots/example-page.png' });
+        
+        await page.goto('https://google.com');
+        await page.screenshot({ path: 'tests/screenshots/google-page.png' });
+
+        // Wait for sync interval
+        await page.waitForTimeout(1000);
+
+        // Check the API endpoint for synced history
+        const apiResponse = await page.request.get('https://api.chroniclesync.xyz/api/history/devices');
+        const data = await apiResponse.json();
+        
+        expect(data.devices).toBeDefined();
+        expect(data.devices.length).toBeGreaterThan(0);
+
+        // Get history for the first device
+        const deviceId = data.devices[0];
+        const historyResponse = await page.request.get(`https://api.chroniclesync.xyz/api/history/${deviceId}`);
+        const historyData = await historyResponse.json();
+
+        expect(historyData.history).toBeDefined();
+        expect(historyData.history.length).toBeGreaterThan(0);
+        
+        // Verify history entries
+        const urls = historyData.history.map(item => item.url);
+        expect(urls).toContain('https://example.com/');
+        expect(urls).toContain('https://google.com/');
+    });
+});

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,0 +1,65 @@
+const request = require('supertest');
+const express = require('express');
+const historyRoutes = require('../worker/history');
+
+const app = express();
+app.use(express.json());
+app.use('/api/history', historyRoutes);
+
+describe('History API', () => {
+    const testHistory = {
+        deviceId: 'test_device_1',
+        items: [
+            {
+                url: 'https://example.com',
+                title: 'Example Domain',
+                lastVisitTime: Date.now(),
+                visitCount: 1
+            },
+            {
+                url: 'https://google.com',
+                title: 'Google',
+                lastVisitTime: Date.now(),
+                visitCount: 5
+            }
+        ]
+    };
+
+    test('POST /api/history/sync - should sync history items', async () => {
+        const response = await request(app)
+            .post('/api/history/sync')
+            .send(testHistory);
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.itemCount).toBe(2);
+    });
+
+    test('GET /api/history/devices - should return list of devices', async () => {
+        // First sync some data
+        await request(app)
+            .post('/api/history/sync')
+            .send(testHistory);
+
+        const response = await request(app)
+            .get('/api/history/devices');
+
+        expect(response.status).toBe(200);
+        expect(response.body.devices).toContain('test_device_1');
+    });
+
+    test('GET /api/history/:deviceId - should return device history', async () => {
+        // First sync some data
+        await request(app)
+            .post('/api/history/sync')
+            .send(testHistory);
+
+        const response = await request(app)
+            .get('/api/history/test_device_1');
+
+        expect(response.status).toBe(200);
+        expect(response.body.history).toHaveLength(2);
+        expect(response.body.history[0].url).toBe('https://example.com');
+        expect(response.body.history[1].url).toBe('https://google.com');
+    });
+});

--- a/worker/app.js
+++ b/worker/app.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const cors = require('cors');
+const historyRoutes = require('./history');
+
+const app = express();
+const port = process.env.PORT || 52529;
+
+app.use(cors({
+    origin: '*',
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    allowedHeaders: ['Content-Type', 'Authorization']
+}));
+
+app.use(express.json());
+
+// API routes
+app.use('/api/history', historyRoutes);
+
+app.listen(port, '0.0.0.0', () => {
+    console.log(`Worker API listening at http://localhost:${port}`);
+});

--- a/worker/history.js
+++ b/worker/history.js
@@ -1,0 +1,57 @@
+const { Router } = require('express');
+const router = Router();
+
+// In-memory storage for demo purposes
+// In production, this should use a proper database
+let historyStore = new Map();
+
+router.post('/sync', async (req, res) => {
+    try {
+        const { deviceId, items } = req.body;
+        
+        if (!deviceId || !Array.isArray(items)) {
+            return res.status(400).json({ error: 'Invalid request format' });
+        }
+
+        // Store history items with device information
+        items.forEach(item => {
+            const key = `${item.url}_${item.lastVisitTime}`;
+            historyStore.set(key, {
+                ...item,
+                deviceId,
+                syncTimestamp: Date.now()
+            });
+        });
+
+        res.json({ success: true, itemCount: items.length });
+    } catch (error) {
+        console.error('History sync error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.get('/devices', async (req, res) => {
+    try {
+        const devices = new Set([...historyStore.values()].map(item => item.deviceId));
+        res.json({ devices: Array.from(devices) });
+    } catch (error) {
+        console.error('Error fetching devices:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.get('/:deviceId', async (req, res) => {
+    try {
+        const { deviceId } = req.params;
+        const deviceHistory = [...historyStore.values()]
+            .filter(item => item.deviceId === deviceId)
+            .sort((a, b) => b.lastVisitTime - a.lastVisitTime);
+        
+        res.json({ history: deviceHistory });
+    } catch (error) {
+        console.error('Error fetching device history:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+module.exports = router;


### PR DESCRIPTION
This PR adds browser history synchronization functionality to ChronicleSync.

### Changes
- Add HistoryManager class for tracking and syncing browser history
- Implement device tracking with unique device IDs
- Add periodic sync (every 5 minutes)
- Store history items with device information and timestamps
- Add E2E tests with Playwright and screenshots
- Add unit tests for worker API
- Update manifest with required permissions

### Testing
1. Install dependencies: `npm install`
2. Run unit tests: `npm test`
3. Run E2E tests: `npm run test:e2e`

The extension will:
- Generate a unique device ID for each installation
- Track and sync browser history every 5 minutes
- Store history with device information
- Use the production API for synchronization