### PR TITLE
Add URL logger extension with Playwright tests

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,5 @@
+chrome.webNavigation.onCompleted.addListener((details) => {
+  if (details.frameId === 0) {  // Only log main frame navigation
+    console.log('Page visited:', details.url);
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 3,
+  "name": "URL Logger",
+  "version": "1.0",
+  "description": "Logs visited URLs to the console",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": [
+    "webNavigation"
+  ]
+}

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+async function getExtensionId(userDataDir) {
+  // Chrome stores extension info in Preferences file
+  const preferencesPath = path.join(userDataDir, 'Default', 'Preferences');
+  const preferences = JSON.parse(fs.readFileSync(preferencesPath, 'utf8'));
+  const extensions = preferences.extensions.settings;
+  
+  // Find our extension by manifest name
+  for (const [id, ext] of Object.entries(extensions)) {
+    if (ext.manifest?.name === 'URL Logger') {
+      return id;
+    }
+  }
+  return null;
+}
+
+test('extension logs visited URLs', async ({ context, browser }) => {
+  // Get the extension ID
+  const userDataDir = browser.userDataDir;
+  const extensionId = await getExtensionId(userDataDir);
+  console.log('Extension ID:', extensionId);
+  
+  // Array to store console logs
+  const logs = [];
+  
+  // Create a page and listen for console messages
+  const page = await context.newPage();
+  page.on('console', msg => {
+    const text = msg.text();
+    console.log('Console log:', text);
+    if (text.startsWith('Page visited:')) {
+      logs.push(text);
+    }
+  });
+
+  // Visit a few test pages
+  await page.goto('https://example.com');
+  await page.waitForTimeout(500); // Wait for logs
+  await page.goto('https://playwright.dev');
+  await page.waitForTimeout(500); // Wait for logs
+  
+  // Visit the extension's background page
+  if (extensionId) {
+    const backgroundPage = await context.newPage();
+    await backgroundPage.goto(`chrome-extension://${extensionId}/_generated_background_page.html`);
+    console.log('Background page loaded');
+  }
+  
+  // Verify logs contain the visited URLs
+  expect(logs.length).toBeGreaterThan(0);
+  expect(logs.some(log => log.includes('example.com'))).toBeTruthy();
+  expect(logs.some(log => log.includes('playwright.dev'))).toBeTruthy();
+});


### PR DESCRIPTION
This PR adds a simple browser extension that logs visited URLs to the console using a background service worker, along with Playwright tests to verify the functionality.

Changes:
- Added manifest.json for extension configuration
- Added background.js with service worker implementation
- Added Playwright test that detects extension ID and verifies URL logging
- Uses Chrome webNavigation API to track page visits

To test the extension manually:
1. Load the extension in Chrome/Edge
2. Visit different pages
3. Check the browser console for URL logs

To run the automated tests:
```bash
npm install
npm test
```

The test will:
- Detect the extension ID automatically
- Verify URL logging functionality
- Access the extension background page
- Provide detailed console output for debugging