### PR TITLE
Add URL logging to background service worker

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,5 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    console.log('Navigation to:', changeInfo.url);
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,9 +6,14 @@
   "action": {
     "default_popup": "popup.html"
   },
+  "background": {
+    "service_worker": "dist/background.js",
+    "type": "module"
+  },
   "permissions": [
     "activeTab",
-    "scripting"
+    "scripting",
+    "tabs"
   ],
   "host_permissions": [
     "http://localhost:*/*",

--- a/pages/config.ts
+++ b/pages/config.ts
@@ -4,7 +4,8 @@ export const paths = {
   extension: resolve(__dirname, '../extension'),
   extensionDist: resolve(__dirname, '../extension/dist'),
   webDist: resolve(__dirname, 'dist'),
-  popup: resolve(__dirname, 'src/popup.tsx')
+  popup: resolve(__dirname, 'src/popup.tsx'),
+  background: resolve(__dirname, 'src/background.ts')
 };
 
 export const server = {

--- a/pages/src/background.ts
+++ b/pages/src/background.ts
@@ -1,0 +1,5 @@
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    console.log('Navigation to:', changeInfo.url);
+  }
+});

--- a/pages/src/background.ts
+++ b/pages/src/background.ts
@@ -1,4 +1,4 @@
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.url) {
     console.log('Navigation to:', changeInfo.url);
   }

--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -17,9 +17,10 @@ export default defineConfig(({ command }) => {
           background: paths.background
         } : 'src/index.tsx',
         output: {
-          format: isExtension ? 'iife' : 'es',
+          format: 'es',
           entryFileNames: '[name].js',
-          assetFileNames: 'assets/[name].[ext]'
+          assetFileNames: 'assets/[name].[ext]',
+          inlineDynamicImports: false
         }
       }
     },

--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -12,7 +12,10 @@ export default defineConfig(({ command }) => {
       outDir: isExtension ? paths.extensionDist : paths.webDist,
       emptyOutDir: true,
       rollupOptions: {
-        input: isExtension ? paths.popup : 'src/index.tsx',
+        input: isExtension ? {
+          popup: paths.popup,
+          background: paths.background
+        } : 'src/index.tsx',
         output: {
           format: isExtension ? 'iife' : 'es',
           entryFileNames: '[name].js',


### PR DESCRIPTION
This PR adds URL logging functionality to the extension by:

- Adding a background service worker in pages/src/background.ts
- Updating the build configuration to include the background script
- Reusing existing build infrastructure to minimize new files
- Adding necessary permissions for URL monitoring

The background service worker logs all URL changes to the console while maintaining the existing code structure.