### PR TITLE
Add test to verify extension loading and service worker

### DIFF
--- a/pages/e2e/extension.spec.ts
+++ b/pages/e2e/extension.spec.ts
@@ -2,6 +2,27 @@ import { test, expect } from './utils/extension';
 import { server } from '../config';
 
 test.describe('Chrome Extension', () => {
+  test('extension should be loaded with correct ID', async ({ context, extensionId }) => {
+    // Verify we got a valid extension ID
+    expect(extensionId).not.toBe('unknown-extension-id');
+    expect(extensionId).toMatch(/^[a-z]{32}$/);
+    console.log('Extension loaded with ID:', extensionId);
+
+    // Open a new page to trigger the background script
+    const testPage = await context.newPage();
+    await testPage.goto('https://example.com');
+    await testPage.waitForTimeout(1000);
+
+    // Check for service workers
+    const workers = await context.serviceWorkers();
+    expect(workers.length).toBe(1);
+
+    // Verify the service worker URL matches our extension
+    const workerUrl = workers[0].url();
+    expect(workerUrl).toContain(extensionId);
+    expect(workerUrl).toContain('background');
+  });
+
   test('API health check should be successful', async ({ page }) => {
     const apiUrl = process.env.API_URL || server.apiUrl;
     console.log('Testing API health at:', `${apiUrl}/health`);

--- a/pages/e2e/utils/extension.ts
+++ b/pages/e2e/utils/extension.ts
@@ -19,12 +19,19 @@ export const test = base.extend<TestFixtures>({
     await context.close();
   },
   extensionId: async ({ context }, use) => {
-    const backgroundPages = context.backgroundPages();
-    const extensionId = backgroundPages.length ? 
-      backgroundPages[0].url().split('/')[2] : 
+    // Open a page to trigger extension loading
+    const page = await context.newPage();
+    await page.goto('https://example.com');
+    await page.waitForTimeout(1000);
+
+    // Get extension ID from service worker
+    const workers = await context.serviceWorkers();
+    const extensionId = workers.length ? 
+      workers[0].url().split('/')[2] : 
       'unknown-extension-id';
-    
+
     await use(extensionId);
+    await page.close();
   },
 });
 


### PR DESCRIPTION
This PR adds a new test that verifies:

1. The extension is loaded and has a valid extension ID
2. The service worker is running and has the correct URL
3. The URL contains both the extension ID and "background"

Changes:
- Added new test in extension.spec.ts
- Fixed extension ID fixture to properly wait for extension loading
- Improved test reliability by using service workers instead of background pages