### PR TITLE
feat: enhance Playwright workflow with configurable API endpoint

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -12,6 +12,11 @@ on:
           - chromium
           - firefox
           - webkit
+      api_endpoint:
+        description: 'API endpoint to test against'
+        required: false
+        type: string
+        default: 'https://api-staging.chroniclesync.xyz'
       debug:
         description: 'Enable debug mode'
         required: false
@@ -42,7 +47,7 @@ jobs:
       - name: Build extension
         working-directory: pages
         env:
-          API_URL: 'https://api-staging.chroniclesync.xyz'
+          API_URL: ${{ inputs.api_endpoint }}
         run: npm run build:extension
 
       - name: Run Playwright tests

--- a/pages/e2e/history-sync.spec.ts
+++ b/pages/e2e/history-sync.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '@playwright/test';
 import { loadExtension } from './utils/extension';
 
 test.describe('History Sync', () => {
+  test.beforeEach(async ({ page }) => {
+    // Verify API endpoint is accessible
+    const apiUrl = process.env.API_URL || 'http://localhost:8787';
+    const response = await page.request.get(`${apiUrl}/health`);
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+    expect(data.healthy).toBeTruthy();
+  });
   test('should sync history across tabs', async ({ context }) => {
     // Load extension in first window
     const extensionId = await loadExtension(context);


### PR DESCRIPTION
This PR enhances the Playwright test workflow to support testing against different API environments.

### Changes

- Add `api_endpoint` input parameter to workflow
- Allow testing against any API environment (local, staging, production)
- Add API health check before running tests
- Update test configuration to use specified endpoint

### Usage

The workflow can now be run with a custom API endpoint:

1. Through GitHub UI:
   - Go to Actions > Playwright Tests
   - Click "Run workflow"
   - Enter API endpoint (defaults to staging)
   - Choose browser and debug options
   - Click "Run workflow"

2. Through GitHub API:
```bash
curl -X POST "...workflows/playwright-tests.yml/dispatches" \
  -d "{\"inputs\": {\"api_endpoint\": \"https://api.example.com\"}}" 
```

This allows testing the extension against any environment that implements the required API endpoints.