### PR TITLE
feat: add API endpoint parameter to Playwright workflow

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -12,6 +12,11 @@ on:
           - chromium
           - firefox
           - webkit
+      api_endpoint:
+        description: 'API endpoint to test against'
+        required: false
+        type: string
+        default: 'https://api-staging.chroniclesync.xyz'
       debug:
         description: 'Enable debug mode'
         required: false
@@ -42,7 +47,7 @@ jobs:
       - name: Build extension
         working-directory: pages
         env:
-          API_URL: 'https://api-staging.chroniclesync.xyz'
+          API_URL: ${{ inputs.api_endpoint }}
         run: npm run build:extension
 
       - name: Run Playwright tests


### PR DESCRIPTION
Add a new input parameter to the Playwright workflow that allows specifying which API endpoint to test against.

### Changes

- Add `api_endpoint` input parameter with staging as default
- Use specified endpoint in extension build

This enables testing against different API environments (local, staging, production) by specifying the endpoint when running the workflow.