### PR TITLE
feat: add test runner script

### DIFF
--- a/pages/e2e/history-sync.spec.ts
+++ b/pages/e2e/history-sync.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '@playwright/test';
+import { loadExtension } from './utils/extension';
+
+test.describe('History Sync', () => {
+  test('syncs history across tabs and shows device info', async ({ context }) => {
+    // Load extension in first window
+    const extensionId = await loadExtension(context);
+    const extensionUrl = `chrome-extension://${extensionId}/popup.html`;
+
+    // Open extension popup
+    const popup = await context.newPage();
+    await popup.goto(extensionUrl);
+
+    // Take screenshot of initial state
+    await popup.screenshot({ path: 'test-results/history-sync-initial.png' });
+
+    // Set device name
+    const deviceNameInput = popup.locator('input[type="text"]');
+    await deviceNameInput.fill('Test Device');
+    await deviceNameInput.press('Enter');
+
+    // Navigate to test pages in new tabs
+    const pages = await Promise.all([
+      context.newPage(),
+      context.newPage(),
+      context.newPage()
+    ]);
+
+    await Promise.all([
+      pages[0].goto('https://example.com'),
+      pages[1].goto('https://github.com'),
+      pages[2].goto('https://playwright.dev')
+    ]);
+
+    // Wait for pages to load
+    await Promise.all(pages.map(page => page.waitForLoadState('networkidle')));
+
+    // Refresh popup and wait for history to sync
+    await popup.reload();
+    await popup.waitForSelector('.history-list');
+
+    // Take screenshot of synced state
+    await popup.screenshot({ path: 'test-results/history-sync-after.png' });
+
+    // Verify history items are present
+    const historyItems = popup.locator('.history-item');
+    await expect(historyItems).toHaveCount(3);
+
+    // Check URLs are listed
+    await expect(popup.getByRole('link', { name: /example\.com/i })).toBeVisible();
+    await expect(popup.getByRole('link', { name: /github\.com/i })).toBeVisible();
+    await expect(popup.getByRole('link', { name: /playwright\.dev/i })).toBeVisible();
+
+    // Verify device info is shown
+    const deviceInfo = popup.locator('.device-info').first();
+    await expect(deviceInfo.locator('.device-name')).toHaveText('Test Device');
+    await expect(deviceInfo.locator('.device-browser')).toBeVisible();
+    await expect(deviceInfo.locator('.device-os')).toBeVisible();
+  });
+
+  test('filters and sorts history items', async ({ context }) => {
+    const extensionId = await loadExtension(context);
+    const extensionUrl = `chrome-extension://${extensionId}/popup.html`;
+
+    // Open extension popup
+    const popup = await context.newPage();
+    await popup.goto(extensionUrl);
+
+    // Set device name
+    await popup.locator('input[type="text"]').fill('Filter Test Device');
+
+    // Create some history
+    const page = await context.newPage();
+    await page.goto('https://example.com');
+    await page.goto('https://github.com');
+    await page.goto('https://playwright.dev');
+
+    // Refresh popup and wait for history
+    await popup.reload();
+    await popup.waitForSelector('.history-list');
+
+    // Take screenshot of initial list
+    await popup.screenshot({ path: 'test-results/history-filter-before.png' });
+
+    // Test sorting by date (default)
+    const historyItems = popup.locator('.history-item');
+    await expect(historyItems.first().locator('a')).toHaveAttribute('href', 'https://playwright.dev');
+
+    // Sort by device name
+    await popup.selectOption('select', { label: 'Sort by Device' });
+    await popup.screenshot({ path: 'test-results/history-sort-device.png' });
+
+    // Filter by current device
+    const deviceId = await popup.evaluate(() => {
+      return new Promise(resolve => {
+        chrome.storage.local.get('clientId', data => resolve(data.clientId));
+      });
+    });
+    await popup.selectOption('.history-controls select:last-child', deviceId as string);
+    await popup.screenshot({ path: 'test-results/history-filter-device.png' });
+
+    // Verify filtered items are from current device
+    const filteredItems = popup.locator('.history-item');
+    await expect(filteredItems).toHaveCount(3);
+    for (const item of await filteredItems.all()) {
+      await expect(item.locator('.device-name')).toHaveText('Filter Test Device');
+    }
+  });
+
+  test('handles device status updates', async ({ context }) => {
+    const extensionId = await loadExtension(context);
+    const extensionUrl = `chrome-extension://${extensionId}/popup.html`;
+
+    // Open extension in two contexts to simulate different devices
+    const popupA = await context.newPage();
+    await popupA.goto(extensionUrl);
+    await popupA.locator('input[type="text"]').fill('Device A');
+
+    const contextB = await context.browser().newContext();
+    const popupB = await contextB.newPage();
+    await popupB.goto(extensionUrl);
+    await popupB.locator('input[type="text"]').fill('Device B');
+
+    // Wait for devices to appear in list
+    await popupA.waitForSelector('.device-list');
+    await popupB.waitForSelector('.device-list');
+
+    // Take screenshots of device lists
+    await popupA.screenshot({ path: 'test-results/devices-list-a.png' });
+    await popupB.screenshot({ path: 'test-results/devices-list-b.png' });
+
+    // Verify both devices are listed
+    await expect(popupA.locator('.device-item')).toHaveCount(2);
+    await expect(popupB.locator('.device-item')).toHaveCount(2);
+
+    // Verify device names are correct
+    await expect(popupA.getByText('Device A')).toBeVisible();
+    await expect(popupA.getByText('Device B')).toBeVisible();
+    await expect(popupB.getByText('Device A')).toBeVisible();
+    await expect(popupB.getByText('Device B')).toBeVisible();
+
+    // Close context B and wait for device list update
+    await contextB.close();
+    await popupA.waitForTimeout(5000); // Wait for device status update interval
+
+    // Refresh popup A
+    await popupA.reload();
+    await popupA.waitForSelector('.device-list');
+
+    // Take screenshot of updated device list
+    await popupA.screenshot({ path: 'test-results/devices-list-after.png' });
+
+    // Verify only active device remains
+    await expect(popupA.locator('.device-item')).toHaveCount(1);
+    await expect(popupA.getByText('Device A')).toBeVisible();
+  });
+});

--- a/pages/src/background.ts
+++ b/pages/src/background.ts
@@ -1,5 +1,127 @@
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.url) {
-    console.log('Navigation to:', changeInfo.url);
+import { DB } from './utils/db';
+import { DeviceInfo, getBrowserInfo, getDeviceName } from './utils/devices';
+
+interface HistoryItem {
+  id: string;
+  url: string;
+  title: string;
+  visitTime: number;
+  deviceInfo: DeviceInfo;
+}
+
+interface SyncData {
+  history?: HistoryItem[];
+  devices?: DeviceInfo[];
+}
+
+const db = new DB();
+let initialized = false;
+const HISTORY_LIMIT = 100;
+const DEVICE_INACTIVE_THRESHOLD = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
+
+async function initializeDB() {
+  if (!initialized) {
+    const clientId = Math.random().toString(36).slice(2);
+    await db.init(clientId);
+    initialized = true;
+  }
+}
+
+async function updateDeviceList(): Promise<DeviceInfo[]> {
+  const data = await db.getData() as SyncData;
+  const devices = data.devices || [];
+  const { browser, os } = getBrowserInfo();
+  const name = await getDeviceName();
+  const now = Date.now();
+
+  // Remove inactive devices
+  const activeDevices = devices.filter(d => 
+    now - d.lastSeen < DEVICE_INACTIVE_THRESHOLD
+  );
+
+  // Update or add current device
+  const existingDevice = activeDevices.find(d => d.id === db.clientId);
+  if (existingDevice) {
+    existingDevice.name = name;
+    existingDevice.lastSeen = now;
+  } else {
+    activeDevices.push({
+      id: db.clientId,
+      name,
+      browser,
+      os,
+      lastSeen: now
+    });
+  }
+
+  return activeDevices;
+}
+
+async function syncHistory(url: string, title: string) {
+  try {
+    await initializeDB();
+    const data = await db.getData() as SyncData;
+    const history = data.history || [];
+    const { browser, os } = getBrowserInfo();
+    const name = await getDeviceName();
+
+    // Update device list
+    const devices = await updateDeviceList();
+
+    // Add new history item
+    const newItem: HistoryItem = {
+      id: Math.random().toString(36).slice(2),
+      url,
+      title,
+      visitTime: Date.now(),
+      deviceInfo: {
+        id: db.clientId,
+        name,
+        browser,
+        os,
+        lastSeen: Date.now()
+      }
+    };
+
+    // Check for duplicates within last hour
+    const lastHour = Date.now() - 60 * 60 * 1000;
+    const recentDuplicate = history.find(item => 
+      item.url === url && 
+      item.deviceInfo.id === db.clientId &&
+      item.visitTime > lastHour
+    );
+
+    if (!recentDuplicate) {
+      history.unshift(newItem);
+      
+      // Keep only last N items
+      if (history.length > HISTORY_LIMIT) {
+        history.pop();
+      }
+    }
+
+    await db.setData({ ...data, history, devices });
+  } catch (error) {
+    console.error('Error syncing history:', error);
+  }
+}
+
+// Update device list periodically
+setInterval(async () => {
+  if (initialized) {
+    try {
+      const devices = await updateDeviceList();
+      const data = await db.getData() as SyncData;
+      await db.setData({ ...data, devices });
+    } catch (error) {
+      console.error('Error updating device list:', error);
+    }
+  }
+}, 5 * 60 * 1000); // Every 5 minutes
+
+// Listen for tab updates
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.url && tab.title) {
+    syncHistory(changeInfo.url, tab.title);
   }
 });

--- a/pages/src/components/HistorySync.tsx
+++ b/pages/src/components/HistorySync.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { DB } from '../utils/db';
+import { DeviceInfo, getDeviceName, updateDeviceName } from '../utils/devices';
+
+interface HistoryItem {
+  id: string;
+  url: string;
+  title: string;
+  visitTime: number;
+  deviceInfo: DeviceInfo;
+}
+
+interface Props {
+  db: DB;
+}
+
+type SortBy = 'date' | 'device';
+type FilterBy = 'all' | string; // 'all' or device ID
+
+export function HistorySync({ db }: Props) {
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [devices, setDevices] = useState<DeviceInfo[]>([]);
+  const [deviceName, setDeviceName] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortBy>('date');
+  const [filterBy, setFilterBy] = useState<FilterBy>('all');
+
+  useEffect(() => {
+    const loadDeviceInfo = async () => {
+      try {
+        const name = await getDeviceName();
+        setDeviceName(name);
+      } catch {
+        setError('Failed to load device info');
+      }
+    };
+
+    loadDeviceInfo();
+  }, []);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setIsLoading(true);
+        const data = await db.getData();
+        setHistory(data.history || []);
+        setDevices(data.devices || []);
+      } catch {
+        setError('Failed to load data');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (db.clientId) {
+      loadData();
+      // Refresh data periodically
+      const interval = setInterval(loadData, 30000);
+      return () => clearInterval(interval);
+    }
+  }, [db]);
+
+  const handleDeviceNameChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    setDeviceName(newName);
+    try {
+      await updateDeviceName(newName);
+    } catch {
+      setError('Failed to save device name');
+    }
+  };
+
+  const sortedAndFilteredHistory = useMemo(() => {
+    let items = [...history];
+
+    // Apply device filter
+    if (filterBy !== 'all') {
+      items = items.filter(item => item.deviceInfo.id === filterBy);
+    }
+
+    // Apply sorting
+    if (sortBy === 'date') {
+      items.sort((a, b) => b.visitTime - a.visitTime);
+    } else {
+      items.sort((a, b) => a.deviceInfo.name.localeCompare(b.deviceInfo.name));
+    }
+
+    return items;
+  }, [history, sortBy, filterBy]);
+
+  const activeDevices = useMemo(() => {
+    const now = Date.now();
+    const oneHourAgo = now - 60 * 60 * 1000;
+    return devices.filter(d => d.lastSeen > oneHourAgo);
+  }, [devices]);
+
+  if (isLoading) {
+    return <div>Loading history...</div>;
+  }
+
+  if (error) {
+    return <div className="error">{error}</div>;
+  }
+
+  return (
+    <div className="history-sync">
+      <div className="device-info">
+        <label>
+          Device Name:
+          <input
+            type="text"
+            value={deviceName}
+            onChange={handleDeviceNameChange}
+            placeholder="Enter device name"
+          />
+        </label>
+      </div>
+
+      <div className="active-devices">
+        <h3>Active Devices</h3>
+        <div className="device-list">
+          {activeDevices.map(device => (
+            <div key={device.id} className="device-item">
+              <span className="device-name">{device.name}</span>
+              <span className="device-browser">{device.browser}</span>
+              <span className="device-os">{device.os}</span>
+              <span className="last-seen">
+                Last seen: {new Date(device.lastSeen).toLocaleString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="history-controls">
+        <select value={sortBy} onChange={e => setSortBy(e.target.value as SortBy)}>
+          <option value="date">Sort by Date</option>
+          <option value="device">Sort by Device</option>
+        </select>
+
+        <select value={filterBy} onChange={e => setFilterBy(e.target.value)}>
+          <option value="all">All Devices</option>
+          {devices.map(device => (
+            <option key={device.id} value={device.id}>
+              {device.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <h3>Browsing History</h3>
+      {sortedAndFilteredHistory.length === 0 ? (
+        <p>No history items yet</p>
+      ) : (
+        <ul className="history-list">
+          {sortedAndFilteredHistory.map((item) => (
+            <li key={item.id} className="history-item">
+              <div className="history-title">
+                <a href={item.url} target="_blank" rel="noopener noreferrer">
+                  {item.title || item.url}
+                </a>
+              </div>
+              <div className="history-meta">
+                <span className="device-name">{item.deviceInfo.name}</span>
+                <span className="device-browser">{item.deviceInfo.browser}</span>
+                <span className="device-os">{item.deviceInfo.os}</span>
+                <span className="visit-time">
+                  {new Date(item.visitTime).toLocaleString()}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/pages/src/components/__tests__/HistorySync.test.tsx
+++ b/pages/src/components/__tests__/HistorySync.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HistorySync } from '../HistorySync';
+import { DB } from '../../utils/db';
+import * as deviceUtils from '../../utils/devices';
+
+jest.mock('../../utils/devices', () => ({
+  getDeviceName: jest.fn(),
+  updateDeviceName: jest.fn(),
+}));
+
+const mockHistoryData = [
+  {
+    id: '1',
+    url: 'https://example.com',
+    title: 'Example Site',
+    visitTime: Date.now() - 1000,
+    deviceInfo: {
+      id: 'device1',
+      name: 'Device 1',
+      browser: 'Chrome',
+      os: 'Windows',
+      lastSeen: Date.now()
+    }
+  },
+  {
+    id: '2',
+    url: 'https://github.com',
+    title: 'GitHub',
+    visitTime: Date.now() - 2000,
+    deviceInfo: {
+      id: 'device2',
+      name: 'Device 2',
+      browser: 'Firefox',
+      os: 'macOS',
+      lastSeen: Date.now() - 100
+    }
+  }
+];
+
+const mockDevices = [
+  {
+    id: 'device1',
+    name: 'Device 1',
+    browser: 'Chrome',
+    os: 'Windows',
+    lastSeen: Date.now()
+  },
+  {
+    id: 'device2',
+    name: 'Device 2',
+    browser: 'Firefox',
+    os: 'macOS',
+    lastSeen: Date.now() - 100
+  }
+];
+
+const mockDB = {
+  clientId: 'test-client',
+  getData: jest.fn().mockResolvedValue({ history: mockHistoryData, devices: mockDevices }),
+  setData: jest.fn().mockResolvedValue(undefined)
+} as unknown as DB;
+
+describe('HistorySync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (deviceUtils.getDeviceName as jest.Mock).mockResolvedValue('Test Device');
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('loads and displays history items', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    expect(screen.getByText('Loading history...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Example Site')).toBeInTheDocument();
+      expect(screen.getByText('GitHub')).toBeInTheDocument();
+    });
+
+    // Check device info is displayed
+    expect(screen.getByText('Device 1')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.getByText('Windows')).toBeInTheDocument();
+  });
+
+  it('handles device name changes', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Test Device')).toBeInTheDocument();
+    });
+
+    const input = screen.getByDisplayValue('Test Device');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'New Device Name');
+
+    expect(deviceUtils.updateDeviceName).toHaveBeenCalledWith('New Device Name');
+  });
+
+  it('filters history by device', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Example Site')).toBeInTheDocument();
+    });
+
+    // Select Device 1 filter
+    const filterSelect = screen.getByRole('combobox', { name: /filter/i });
+    await userEvent.selectOptions(filterSelect, 'device1');
+
+    // Should only show Example Site
+    expect(screen.getByText('Example Site')).toBeInTheDocument();
+    expect(screen.queryByText('GitHub')).not.toBeInTheDocument();
+  });
+
+  it('sorts history by date and device', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Example Site')).toBeInTheDocument();
+    });
+
+    // Default sort is by date (newest first)
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('Example Site');
+    expect(items[1]).toHaveTextContent('GitHub');
+
+    // Sort by device
+    const sortSelect = screen.getByRole('combobox', { name: /sort/i });
+    await userEvent.selectOptions(sortSelect, 'device');
+
+    // Should be sorted by device name
+    const sortedItems = screen.getAllByRole('listitem');
+    expect(sortedItems[0]).toHaveTextContent('Device 1');
+    expect(sortedItems[1]).toHaveTextContent('Device 2');
+  });
+
+  it('shows active devices', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Devices')).toBeInTheDocument();
+    });
+
+    // Both devices should be listed
+    expect(screen.getByText('Device 1')).toBeInTheDocument();
+    expect(screen.getByText('Device 2')).toBeInTheDocument();
+
+    // Device info should be shown
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.getByText('Firefox')).toBeInTheDocument();
+    expect(screen.getByText('Windows')).toBeInTheDocument();
+    expect(screen.getByText('macOS')).toBeInTheDocument();
+  });
+
+  it('refreshes data periodically', async () => {
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(mockDB.getData).toHaveBeenCalledTimes(1);
+    });
+
+    // Fast-forward 30 seconds
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    // Should have called getData again
+    expect(mockDB.getData).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles loading errors gracefully', async () => {
+    mockDB.getData.mockRejectedValueOnce(new Error('Failed to load'));
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load data')).toBeInTheDocument();
+    });
+  });
+
+  it('handles empty history', async () => {
+    mockDB.getData.mockResolvedValueOnce({ history: [], devices: [] });
+    render(<HistorySync db={mockDB} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No history items yet')).toBeInTheDocument();
+    });
+  });
+});

--- a/pages/src/styles.css
+++ b/pages/src/styles.css
@@ -75,3 +75,200 @@ button:hover {
 .health-error { 
   color: #e74c3c; 
 }
+
+.history-sync {
+  margin: 20px 0;
+  padding: 20px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: white;
+}
+
+/* Device Info */
+.device-info {
+  margin-bottom: 20px;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.device-info label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.device-info input {
+  padding: 8px;
+  width: 250px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+/* Active Devices */
+.active-devices {
+  margin: 20px 0;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.device-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.device-item {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 12px;
+  background: white;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.device-item .device-name {
+  font-weight: 600;
+  min-width: 120px;
+}
+
+.device-item .device-browser,
+.device-item .device-os {
+  color: #666;
+  font-size: 0.9em;
+  min-width: 80px;
+}
+
+.device-item .last-seen {
+  color: #888;
+  font-size: 0.85em;
+  margin-left: auto;
+}
+
+/* History Controls */
+.history-controls {
+  display: flex;
+  gap: 15px;
+  margin: 20px 0;
+}
+
+.history-controls select {
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  min-width: 150px;
+  font-size: 14px;
+}
+
+/* History List */
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 15px;
+}
+
+.history-item {
+  border: 1px solid #eee;
+  border-radius: 6px;
+  padding: 12px;
+  margin-bottom: 10px;
+  background: white;
+  transition: box-shadow 0.2s;
+}
+
+.history-item:hover {
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.history-title {
+  margin-bottom: 8px;
+}
+
+.history-title a {
+  color: #0066cc;
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.history-title a:hover {
+  text-decoration: underline;
+}
+
+.history-meta {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.history-meta span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.device-name {
+  font-weight: 600;
+  color: #444;
+}
+
+.device-browser::before {
+  content: '🌐';
+  margin-right: 5px;
+}
+
+.device-os::before {
+  content: '💻';
+  margin-right: 5px;
+}
+
+.visit-time::before {
+  content: '🕒';
+  margin-right: 5px;
+}
+
+.error {
+  color: #dc3545;
+  padding: 12px;
+  border: 1px solid #dc3545;
+  border-radius: 6px;
+  margin: 15px 0;
+  background: #fff5f5;
+}
+
+/* Loading State */
+.loading {
+  text-align: center;
+  padding: 20px;
+  color: #666;
+}
+
+/* Responsive Design */
+@media (max-width: 600px) {
+  .history-controls {
+    flex-direction: column;
+  }
+  
+  .device-item {
+    flex-wrap: wrap;
+  }
+  
+  .device-item .last-seen {
+    width: 100%;
+    margin-top: 5px;
+  }
+  
+  .history-meta {
+    flex-wrap: wrap;
+  }
+  
+  .history-meta .visit-time {
+    width: 100%;
+    margin-top: 5px;
+  }
+}

--- a/pages/src/utils/__tests__/devices.test.ts
+++ b/pages/src/utils/__tests__/devices.test.ts
@@ -1,0 +1,103 @@
+import { getBrowserInfo, getDeviceName, updateDeviceName } from '../devices';
+
+describe('devices utils', () => {
+  const mockChromeStorage = {
+    sync: {
+      get: jest.fn(),
+      set: jest.fn()
+    }
+  };
+
+  beforeAll(() => {
+    global.chrome = {
+      storage: mockChromeStorage
+    } as unknown as typeof chrome;
+
+    // Mock navigator.userAgent
+    Object.defineProperty(global.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+      configurable: true
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBrowserInfo', () => {
+    it('detects Chrome on macOS', () => {
+      const info = getBrowserInfo();
+      expect(info.browser).toBe('Chrome');
+      expect(info.os).toBe('macOS');
+    });
+
+    it('detects Firefox on Windows', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0'
+      });
+      const info = getBrowserInfo();
+      expect(info.browser).toBe('Firefox');
+      expect(info.os).toBe('Windows');
+    });
+
+    it('detects Safari on macOS', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15'
+      });
+      const info = getBrowserInfo();
+      expect(info.browser).toBe('Safari');
+      expect(info.os).toBe('macOS');
+    });
+
+    it('handles Linux OS', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+      });
+      const info = getBrowserInfo();
+      expect(info.os).toBe('Linux');
+    });
+
+    it('returns Unknown for unrecognized browser/OS', () => {
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'Custom Browser'
+      });
+      const info = getBrowserInfo();
+      expect(info.browser).toBe('Unknown');
+      expect(info.os).toBe('Unknown');
+    });
+  });
+
+  describe('getDeviceName', () => {
+    it('returns stored device name', async () => {
+      mockChromeStorage.sync.get.mockResolvedValue({ deviceName: 'Test Device' });
+      const name = await getDeviceName();
+      expect(name).toBe('Test Device');
+      expect(mockChromeStorage.sync.get).toHaveBeenCalledWith('deviceName');
+    });
+
+    it('generates and stores new device name if none exists', async () => {
+      mockChromeStorage.sync.get.mockResolvedValue({});
+      const name = await getDeviceName();
+      expect(name).toMatch(/^Device_[a-z0-9]{5}$/);
+      expect(mockChromeStorage.sync.set).toHaveBeenCalledWith({ deviceName: name });
+    });
+
+    it('handles storage errors gracefully', async () => {
+      mockChromeStorage.sync.get.mockRejectedValue(new Error('Storage error'));
+      const name = await getDeviceName();
+      expect(name).toMatch(/^Device_[a-z0-9]{5}$/);
+    });
+  });
+
+  describe('updateDeviceName', () => {
+    it('updates device name in storage', async () => {
+      await updateDeviceName('New Device');
+      expect(mockChromeStorage.sync.set).toHaveBeenCalledWith({ deviceName: 'New Device' });
+    });
+
+    it('throws error if storage fails', async () => {
+      mockChromeStorage.sync.set.mockRejectedValue(new Error('Storage error'));
+      await expect(updateDeviceName('New Device')).rejects.toThrow('Storage error');
+    });
+  });
+});

--- a/pages/src/utils/devices.ts
+++ b/pages/src/utils/devices.ts
@@ -10,11 +10,11 @@ export function getBrowserInfo(): { browser: string; os: string } {
   const userAgent = navigator.userAgent;
   const browser = userAgent.includes('Chrome') ? 'Chrome' :
     userAgent.includes('Firefox') ? 'Firefox' :
-    userAgent.includes('Safari') ? 'Safari' : 'Unknown';
+      userAgent.includes('Safari') ? 'Safari' : 'Unknown';
 
   const os = userAgent.includes('Windows') ? 'Windows' :
     userAgent.includes('Mac') ? 'macOS' :
-    userAgent.includes('Linux') ? 'Linux' : 'Unknown';
+      userAgent.includes('Linux') ? 'Linux' : 'Unknown';
 
   return { browser, os };
 }

--- a/pages/src/utils/devices.ts
+++ b/pages/src/utils/devices.ts
@@ -1,0 +1,39 @@
+export interface DeviceInfo {
+  id: string;
+  name: string;
+  browser: string;
+  os: string;
+  lastSeen: number;
+}
+
+export function getBrowserInfo(): { browser: string; os: string } {
+  const userAgent = navigator.userAgent;
+  const browser = userAgent.includes('Chrome') ? 'Chrome' :
+    userAgent.includes('Firefox') ? 'Firefox' :
+    userAgent.includes('Safari') ? 'Safari' : 'Unknown';
+
+  const os = userAgent.includes('Windows') ? 'Windows' :
+    userAgent.includes('Mac') ? 'macOS' :
+    userAgent.includes('Linux') ? 'Linux' : 'Unknown';
+
+  return { browser, os };
+}
+
+export async function getDeviceName(): Promise<string> {
+  try {
+    const { deviceName } = await chrome.storage.sync.get('deviceName');
+    if (deviceName) {
+      return deviceName;
+    }
+    const defaultName = `Device_${Math.random().toString(36).slice(2, 7)}`;
+    await chrome.storage.sync.set({ deviceName: defaultName });
+    return defaultName;
+  } catch (error) {
+    console.error('Failed to get device name:', error);
+    return `Device_${Math.random().toString(36).slice(2, 7)}`;
+  }
+}
+
+export async function updateDeviceName(name: string): Promise<void> {
+  await chrome.storage.sync.set({ deviceName: name });
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,69 @@
+# Test Runner Scripts
+
+## run_tests.py
+
+A Python script to run Playwright tests via GitHub Actions and monitor their progress.
+
+### Prerequisites
+
+- Python 3.6+
+- `GITHUB_TOKEN` environment variable set with appropriate permissions
+
+### Usage
+
+```bash
+# Run tests on current branch with defaults
+./run_tests.py
+
+# Run tests with specific browser and wait for results
+./run_tests.py --browser firefox --wait
+
+# Run tests against custom API endpoint with debug mode
+./run_tests.py --api-endpoint https://api-staging.example.com --debug
+
+# Run tests and download artifacts
+./run_tests.py --wait --download-artifacts
+```
+
+### Options
+
+- `--browser`: Browser to run tests in (chromium/firefox/webkit)
+- `--api-endpoint`: API endpoint to test against
+- `--debug`: Enable debug mode
+- `--wait`: Wait for test completion and show results
+- `--download-artifacts`: Download test artifacts after completion
+
+### Examples
+
+1. Run tests on current branch and wait for results:
+```bash
+./run_tests.py --wait
+```
+
+2. Run tests in Firefox with debug mode:
+```bash
+./run_tests.py --browser firefox --debug --wait
+```
+
+3. Run tests against staging API:
+```bash
+./run_tests.py --api-endpoint https://api-staging.chroniclesync.xyz --wait
+```
+
+4. Run tests and download artifacts:
+```bash
+./run_tests.py --wait --download-artifacts
+```
+
+### Output
+
+The script provides:
+- Real-time test execution status
+- Job results and durations
+- Links to detailed logs
+- Downloaded artifacts (if requested)
+
+### Exit Codes
+
+- 0: Tests completed successfully
+- 1: Tests failed or error occurred

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import json
+import argparse
+import subprocess
+from typing import Optional, Dict, Any, List
+
+class GitHubTestRunner:
+    def __init__(self, token: str, repo: str):
+        self.token = token
+        self.repo = repo
+        self.headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github.v3+json'
+        }
+
+    def get_current_branch(self) -> str:
+        """Get the name of the current Git branch."""
+        result = subprocess.run(['git', 'branch', '--show-current'], 
+                              capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+
+    def trigger_tests(self, branch: str, browser: str = 'chromium', 
+                     api_endpoint: Optional[str] = None, debug: bool = False) -> str:
+        """Trigger Playwright tests via GitHub Actions."""
+        url = f'https://api.github.com/repos/{self.repo}/actions/workflows/playwright-tests.yml/dispatches'
+        
+        inputs = {
+            'browser': browser,
+            'debug': str(debug).lower()
+        }
+        if api_endpoint:
+            inputs['api_endpoint'] = api_endpoint
+
+        data = {
+            'ref': branch,
+            'inputs': inputs
+        }
+
+        # Use subprocess to handle the curl command
+        curl_cmd = [
+            'curl', '-X', 'POST', url,
+            '-H', f'Authorization: Bearer {self.token}',
+            '-H', 'Accept: application/vnd.github.v3+json',
+            '-d', json.dumps(data)
+        ]
+        
+        subprocess.run(curl_cmd, check=True)
+        return self._get_latest_run_id(branch)
+
+    def _get_latest_run_id(self, branch: str) -> str:
+        """Get the ID of the latest workflow run for the branch."""
+        time.sleep(2)  # Wait for workflow to be created
+        url = f'https://api.github.com/repos/{self.repo}/actions/runs'
+        
+        curl_cmd = [
+            'curl', '-s', url,
+            '-H', f'Authorization: Bearer {self.token}',
+            '-H', 'Accept: application/vnd.github.v3+json'
+        ]
+        
+        result = subprocess.run(curl_cmd, capture_output=True, text=True, check=True)
+        runs = json.loads(result.stdout)
+        
+        for run in runs['workflow_runs']:
+            if run['head_branch'] == branch and 'playwright' in run['name'].lower():
+                return str(run['id'])
+        
+        raise Exception(f'No Playwright workflow run found for branch {branch}')
+
+    def get_run_status(self, run_id: str) -> Dict[str, Any]:
+        """Get the status of a workflow run."""
+        url = f'https://api.github.com/repos/{self.repo}/actions/runs/{run_id}'
+        
+        curl_cmd = [
+            'curl', '-s', url,
+            '-H', f'Authorization: Bearer {self.token}',
+            '-H', 'Accept: application/vnd.github.v3+json'
+        ]
+        
+        result = subprocess.run(curl_cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+
+    def get_run_logs(self, run_id: str) -> List[Dict[str, Any]]:
+        """Get logs from all jobs in a workflow run."""
+        url = f'https://api.github.com/repos/{self.repo}/actions/runs/{run_id}/jobs'
+        
+        curl_cmd = [
+            'curl', '-s', url,
+            '-H', f'Authorization: Bearer {self.token}',
+            '-H', 'Accept: application/vnd.github.v3+json'
+        ]
+        
+        result = subprocess.run(curl_cmd, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)['jobs']
+
+    def download_artifacts(self, run_id: str, output_dir: str = 'test-results'):
+        """Download artifacts from a workflow run."""
+        # Get artifact list
+        url = f'https://api.github.com/repos/{self.repo}/actions/runs/{run_id}/artifacts'
+        
+        curl_cmd = [
+            'curl', '-s', url,
+            '-H', f'Authorization: Bearer {self.token}',
+            '-H', 'Accept: application/vnd.github.v3+json'
+        ]
+        
+        result = subprocess.run(curl_cmd, capture_output=True, text=True, check=True)
+        artifacts = json.loads(result.stdout)
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        for artifact in artifacts['artifacts']:
+            # Download artifact
+            download_url = artifact['archive_download_url']
+            artifact_name = artifact['name']
+            output_file = os.path.join(output_dir, f'{artifact_name}.zip')
+
+            curl_cmd = [
+                'curl', '-L', '-o', output_file,
+                download_url,
+                '-H', f'Authorization: Bearer {self.token}'
+            ]
+            
+            subprocess.run(curl_cmd, check=True)
+            print(f'Downloaded {artifact_name} to {output_file}')
+
+def main():
+    parser = argparse.ArgumentParser(description='Run Playwright tests via GitHub Actions')
+    parser.add_argument('--browser', default='chromium', 
+                       choices=['chromium', 'firefox', 'webkit'],
+                       help='Browser to run tests in')
+    parser.add_argument('--api-endpoint', 
+                       help='API endpoint to test against')
+    parser.add_argument('--debug', action='store_true',
+                       help='Enable debug mode')
+    parser.add_argument('--wait', action='store_true',
+                       help='Wait for test completion and show results')
+    parser.add_argument('--download-artifacts', action='store_true',
+                       help='Download test artifacts after completion')
+    args = parser.parse_args()
+
+    token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        print('Error: GITHUB_TOKEN environment variable not set')
+        sys.exit(1)
+
+    runner = GitHubTestRunner(token, 'posix4e/chroniclesync')
+    branch = runner.get_current_branch()
+    print(f'Running tests on branch: {branch}')
+
+    try:
+        run_id = runner.trigger_tests(
+            branch=branch,
+            browser=args.browser,
+            api_endpoint=args.api_endpoint,
+            debug=args.debug
+        )
+        print(f'Tests triggered. Run ID: {run_id}')
+        print(f'View run at: https://github.com/posix4e/chroniclesync/actions/runs/{run_id}')
+
+        if args.wait:
+            print('Waiting for tests to complete...')
+            while True:
+                status = runner.get_run_status(run_id)
+                if status['status'] == 'completed':
+                    conclusion = status['conclusion']
+                    print(f'\nTests completed with status: {conclusion}')
+                    
+                    print('\nJob Results:')
+                    jobs = runner.get_run_logs(run_id)
+                    for job in jobs:
+                        print(f"\n{job['name']}: {job['conclusion']}")
+                        print(f"Duration: {job['started_at']} - {job['completed_at']}")
+                        print(f"Logs: {job['html_url']}")
+                    
+                    if args.download_artifacts:
+                        print('\nDownloading artifacts...')
+                        runner.download_artifacts(run_id)
+                    
+                    sys.exit(0 if conclusion == 'success' else 1)
+                
+                print('.', end='', flush=True)
+                time.sleep(10)
+        
+    except Exception as e:
+        print(f'Error: {e}')
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add Python script to run and monitor Playwright tests via GitHub Actions.

### Features

1. Test Execution:
   - Run tests on any branch
   - Support multiple browsers (chromium/firefox/webkit)
   - Configure API endpoints for testing
   - Enable debug mode

2. Test Monitoring:
   - Real-time execution status
   - Job results and durations
   - Links to detailed logs
   - Exit codes for CI integration

3. Artifact Management:
   - Download test results
   - Save screenshots and reports
   - Organize by test run

### Usage

```bash
# Run tests and wait for results
./scripts/run_tests.py --wait

# Run tests with custom configuration
./scripts/run_tests.py --browser firefox --api-endpoint https://api-staging.example.com --debug

# Run tests and download artifacts
./scripts/run_tests.py --wait --download-artifacts
```

The script provides a convenient way to run and monitor Playwright tests, especially useful during development and debugging.