### PR TITLE
Add history sync feature with tests

### DIFF
--- a/pages/e2e/extension-page-interaction.spec.ts
+++ b/pages/e2e/extension-page-interaction.spec.ts
@@ -103,6 +103,109 @@ test.describe('Extension-Page Integration', () => {
     expect(errors).toEqual([]);
   });
 
+  test('history view shows synced browsing data', async ({ context, extensionId }) => {
+    const extensionPage = await context.newPage();
+    
+    // Mock the API response
+    await extensionPage.route('**/*', async (route, request) => {
+      if (request.url().includes('api-staging.chroniclesync.xyz/history')) {
+        if (request.method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              {
+                url: 'https://example.com',
+                title: 'Example Domain',
+                timestamp: Date.now() - 1000,
+                deviceId: 'device1',
+                deviceInfo: {
+                  platform: 'Windows',
+                  browser: 'Chrome',
+                  version: '120.0.0'
+                }
+              },
+              {
+                url: 'https://test.com',
+                title: 'Test Site',
+                timestamp: Date.now(),
+                deviceId: 'device2',
+                deviceInfo: {
+                  platform: 'MacOS',
+                  browser: 'Chrome',
+                  version: '120.0.0'
+                }
+              }
+            ])
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'History saved' })
+          });
+        }
+      } else {
+        await route.continue();
+      }
+    });
+
+    await extensionPage.goto(`file://${process.cwd()}/../extension/popup.html`);
+    await extensionPage.waitForLoadState('networkidle');
+
+    // Switch to history tab
+    await extensionPage.click('button:has-text("History")');
+    await extensionPage.waitForTimeout(1000);
+
+    // Verify history entries
+    const historyItems = await extensionPage.locator('.history-item').count();
+    expect(historyItems).toBe(2);
+
+    // Verify device filtering
+    const deviceSelect = await extensionPage.locator('select');
+    await deviceSelect.selectOption({ index: 1 }); // First device
+    await extensionPage.waitForTimeout(500);
+    const filteredItems = await extensionPage.locator('.history-item').count();
+    expect(filteredItems).toBe(1);
+  });
+
+  test('history syncs in real-time', async ({ context, extensionId }) => {
+    const errors: string[] = [];
+    const extensionPage = await context.newPage();
+    extensionPage.on('console', msg => {
+      if (msg.type() === 'error') {
+        errors.push(msg.text());
+      }
+    });
+
+    // Mock API responses
+    await extensionPage.route('**/*', async (route, request) => {
+      if (request.url().includes('api-staging.chroniclesync.xyz/history')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'History saved' })
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Navigate to test pages
+    const testPage = await context.newPage();
+    await testPage.goto('https://example.com');
+    await testPage.waitForTimeout(1000);
+
+    // Open extension and check history
+    await extensionPage.goto(`file://${process.cwd()}/../extension/popup.html`);
+    await extensionPage.waitForLoadState('networkidle');
+    await extensionPage.click('button:has-text("History")');
+    await extensionPage.waitForTimeout(1000);
+
+    // Verify no errors occurred
+    expect(errors).toEqual([]);
+  });
+
   test.afterEach(async ({ page }, testInfo) => {
     // Capture a screenshot after each test if it fails
     if (testInfo.status !== testInfo.expectedStatus) {

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -3,29 +3,82 @@ import { ClientSection } from './components/ClientSection';
 import { AdminPanel } from './components/AdminPanel';
 import { AdminLogin } from './components/AdminLogin';
 import { HealthCheck } from './components/HealthCheck';
+import HistoryView from './components/HistoryView';
 import { DB } from './utils/db';
 
 const db = new DB();
 
 export function App() {
   const [isAdminLoggedIn, setIsAdminLoggedIn] = useState(false);
+  const [activeTab, setActiveTab] = useState('sync');
 
   return (
     <div className="container">
       <h1>ChronicleSync</h1>
       
-      <ClientSection db={db} />
-      
-      {!isAdminLoggedIn ? (
-        <div id="adminLogin">
-          <h2>Admin Login</h2>
-          <AdminLogin onLogin={() => setIsAdminLoggedIn(true)} />
-        </div>
+      <div className="tabs">
+        <button
+          className={`tab ${activeTab === 'sync' ? 'active' : ''}`}
+          onClick={() => setActiveTab('sync')}
+        >
+          Sync
+        </button>
+        <button
+          className={`tab ${activeTab === 'history' ? 'active' : ''}`}
+          onClick={() => setActiveTab('history')}
+        >
+          History
+        </button>
+      </div>
+
+      {activeTab === 'sync' ? (
+        <>
+          <ClientSection db={db} />
+          
+          {!isAdminLoggedIn ? (
+            <div id="adminLogin">
+              <h2>Admin Login</h2>
+              <AdminLogin onLogin={() => setIsAdminLoggedIn(true)} />
+            </div>
+          ) : (
+            <AdminPanel />
+          )}
+        </>
       ) : (
-        <AdminPanel />
+        <HistoryView />
       )}
       
       <HealthCheck />
+
+      <style>{`
+        .tabs {
+          display: flex;
+          gap: 10px;
+          margin-bottom: 20px;
+        }
+
+        .tab {
+          padding: 8px 16px;
+          border: 1px solid #ddd;
+          border-radius: 4px;
+          background: none;
+          cursor: pointer;
+        }
+
+        .tab.active {
+          background: #0066cc;
+          color: white;
+          border-color: #0066cc;
+        }
+
+        .tab:hover {
+          background: #f0f0f0;
+        }
+
+        .tab.active:hover {
+          background: #0055aa;
+        }
+      `}</style>
     </div>
   );
 }

--- a/pages/src/background.ts
+++ b/pages/src/background.ts
@@ -1,5 +1,90 @@
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.url) {
-    console.log('Navigation to:', changeInfo.url);
+interface HistoryEntry {
+  url: string;
+  title?: string;
+  timestamp: number;
+  deviceId: string;
+  deviceInfo: {
+    platform: string;
+    browser: string;
+    version: string;
+  };
+}
+
+let deviceId: string;
+
+const getDeviceInfo = () => ({
+  platform: navigator.platform,
+  browser: 'Chrome',
+  version: navigator.userAgent.match(/Chrome\/([0-9.]+)/)?.[1] || 'unknown'
+});
+
+const initDeviceId = async () => {
+  const stored = await chrome.storage.local.get('deviceId');
+  if (stored.deviceId) {
+    deviceId = stored.deviceId;
+  } else {
+    deviceId = crypto.randomUUID();
+    await chrome.storage.local.set({ deviceId });
+  }
+};
+
+const storeHistoryEntry = async (entry: HistoryEntry) => {
+  const key = `history_${entry.timestamp}`;
+  await chrome.storage.local.set({ [key]: entry });
+  
+  // Sync to server
+  try {
+    const response = await fetch(`${process.env.API_URL || 'https://api-staging.chroniclesync.xyz'}/history`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(entry)
+    });
+    if (!response.ok) throw new Error('Failed to sync history');
+  } catch (error) {
+    console.error('Failed to sync history:', error);
+    // Store failed sync attempts for retry
+    const failedSyncs = await chrome.storage.local.get('failedSyncs') || { failedSyncs: [] };
+    failedSyncs.failedSyncs.push(entry);
+    await chrome.storage.local.set({ failedSyncs: failedSyncs.failedSyncs });
+  }
+};
+
+// Initialize device ID
+initDeviceId();
+
+// Listen for navigation events
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.url && tab.title) {
+    const entry: HistoryEntry = {
+      url: changeInfo.url,
+      title: tab.title,
+      timestamp: Date.now(),
+      deviceId,
+      deviceInfo: getDeviceInfo()
+    };
+    await storeHistoryEntry(entry);
   }
 });
+
+// Retry failed syncs periodically
+setInterval(async () => {
+  const { failedSyncs = [] } = await chrome.storage.local.get('failedSyncs');
+  if (failedSyncs.length === 0) return;
+
+  const retryPromises = failedSyncs.map(async (entry: HistoryEntry) => {
+    try {
+      await fetch(`${process.env.API_URL || 'https://api-staging.chroniclesync.xyz'}/history`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(entry)
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  const results = await Promise.all(retryPromises);
+  const remainingFailures = failedSyncs.filter((_: HistoryEntry, i: number) => !results[i]);
+  await chrome.storage.local.set({ failedSyncs: remainingFailures });
+}, 60000); // Retry every minute

--- a/pages/src/components/HistoryView.tsx
+++ b/pages/src/components/HistoryView.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+
+interface HistoryEntry {
+  url: string;
+  title?: string;
+  timestamp: number;
+  deviceId: string;
+  deviceInfo: {
+    platform: string;
+    browser: string;
+    version: string;
+  };
+}
+
+interface DeviceInfo {
+  deviceId: string;
+  lastSeen: number;
+  platform: string;
+  browser: string;
+  version: string;
+}
+
+const HistoryView: React.FC = () => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [devices, setDevices] = useState<DeviceInfo[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<string>('all');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const response = await fetch(`${process.env.API_URL || 'https://api-staging.chroniclesync.xyz'}/history`);
+        if (!response.ok) throw new Error('Failed to fetch history');
+        const data = await response.json();
+        setHistory(data);
+
+        // Extract unique devices
+        const deviceMap = new Map<string, DeviceInfo>();
+        data.forEach((entry: HistoryEntry) => {
+          if (!deviceMap.has(entry.deviceId)) {
+            deviceMap.set(entry.deviceId, {
+              deviceId: entry.deviceId,
+              lastSeen: entry.timestamp,
+              ...entry.deviceInfo
+            });
+          } else {
+            const device = deviceMap.get(entry.deviceId)!;
+            if (entry.timestamp > device.lastSeen) {
+              device.lastSeen = entry.timestamp;
+            }
+          }
+        });
+        setDevices(Array.from(deviceMap.values()));
+        setLoading(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+        setLoading(false);
+      }
+    };
+
+    fetchHistory();
+    const interval = setInterval(fetchHistory, 30000); // Refresh every 30 seconds
+    return () => clearInterval(interval);
+  }, []);
+
+  const filteredHistory = selectedDevice === 'all'
+    ? history
+    : history.filter(entry => entry.deviceId === selectedDevice);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div className="history-view">
+      <h2>Browsing History</h2>
+      
+      <div className="device-selector">
+        <label>
+          Filter by Device:
+          <select
+            value={selectedDevice}
+            onChange={(e) => setSelectedDevice(e.target.value)}
+          >
+            <option value="all">All Devices</option>
+            {devices.map(device => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {device.platform} - {device.browser} {device.version}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="history-list">
+        {filteredHistory.map((entry, index) => (
+          <div key={index} className="history-item">
+            <div className="history-title">
+              <a href={entry.url} target="_blank" rel="noopener noreferrer">
+                {entry.title || entry.url}
+              </a>
+            </div>
+            <div className="history-meta">
+              <span className="history-time">
+                {new Date(entry.timestamp).toLocaleString()}
+              </span>
+              <span className="history-device">
+                {devices.find(d => d.deviceId === entry.deviceId)?.platform} - 
+                {devices.find(d => d.deviceId === entry.deviceId)?.browser}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        .history-view {
+          padding: 20px;
+          max-width: 800px;
+          margin: 0 auto;
+        }
+
+        .device-selector {
+          margin: 20px 0;
+        }
+
+        .device-selector select {
+          margin-left: 10px;
+          padding: 5px;
+        }
+
+        .history-list {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+        }
+
+        .history-item {
+          padding: 10px;
+          border: 1px solid #ddd;
+          border-radius: 4px;
+        }
+
+        .history-title {
+          font-size: 16px;
+          margin-bottom: 5px;
+        }
+
+        .history-title a {
+          color: #0066cc;
+          text-decoration: none;
+        }
+
+        .history-title a:hover {
+          text-decoration: underline;
+        }
+
+        .history-meta {
+          font-size: 12px;
+          color: #666;
+          display: flex;
+          justify-content: space-between;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default HistoryView;

--- a/pages/src/components/__tests__/HistoryView.test.tsx
+++ b/pages/src/components/__tests__/HistoryView.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HistoryView from '../HistoryView';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('HistoryView', () => {
+  const mockHistory = [
+    {
+      url: 'https://example.com',
+      title: 'Example Site',
+      timestamp: Date.now(),
+      deviceId: 'device1',
+      deviceInfo: {
+        platform: 'Windows',
+        browser: 'Chrome',
+        version: '120.0.0'
+      }
+    },
+    {
+      url: 'https://test.com',
+      title: 'Test Site',
+      timestamp: Date.now() - 1000,
+      deviceId: 'device2',
+      deviceInfo: {
+        platform: 'MacOS',
+        browser: 'Chrome',
+        version: '120.0.0'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  it('renders history entries and allows filtering by device', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockHistory
+    });
+
+    render(<HistoryView />);
+
+    // Wait for history to load
+    await waitFor(() => {
+      expect(screen.getByText('Example Site')).toBeInTheDocument();
+    });
+
+    // Check if both entries are visible
+    expect(screen.getByText('Example Site')).toBeInTheDocument();
+    expect(screen.getByText('Test Site')).toBeInTheDocument();
+
+    // Check device filter options
+    const deviceSelect = screen.getByLabelText(/Filter by Device/i);
+    expect(deviceSelect).toBeInTheDocument();
+
+    // Filter by first device
+    await userEvent.selectOptions(deviceSelect, 'device1');
+    expect(screen.getByText('Example Site')).toBeInTheDocument();
+    expect(screen.queryByText('Test Site')).not.toBeInTheDocument();
+
+    // Filter by second device
+    await userEvent.selectOptions(deviceSelect, 'device2');
+    expect(screen.queryByText('Example Site')).not.toBeInTheDocument();
+    expect(screen.getByText('Test Site')).toBeInTheDocument();
+  });
+
+  it('handles API errors gracefully', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+
+    render(<HistoryView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error:/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state', () => {
+    (global.fetch as jest.Mock).mockImplementationOnce(() => new Promise(() => {}));
+
+    render(<HistoryView />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds a history sync feature that allows tracking and syncing browser history across multiple devices.

Changes:
- Add history tracking in background script
- Add history view component with device filtering
- Add history sync tests to extension-page-interaction.spec.ts
- Follow existing test patterns and API mocking
- Use staging API endpoint for tests

The feature requires no changes to the worker or GitHub Actions configuration.