### PR TITLE
Fix Chrome extension packaging in CI workflow

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -61,14 +61,13 @@ jobs:
       - name: Package Chrome Extension
         working-directory: pages
         run: |
-          cd ..
-          zip -r chrome-extension.zip extension/
+          zip -r chrome-extension.zip dist/
 
       - name: Upload Extension Artifact
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension
-          path: chrome-extension.zip
+          path: pages/chrome-extension.zip
           retention-days: 14
 
       - name: Test Worker


### PR DESCRIPTION
This PR fixes the Chrome extension packaging step in the CI workflow to match the new directory structure:

- Update extension packaging to use `pages/dist/` directory
- Fix artifact path to use `pages/chrome-extension.zip`

These changes align with the directory structure changes made in PR #220.