### PR TITLE
Switch to non-persistent background page

### DIFF
--- a/pages/.eslintrc.js
+++ b/pages/.eslintrc.js
@@ -28,8 +28,8 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     'quotes': ['error', 'single'],
     'semi': ['error', 'always'],
-    'no-unused-vars': ['error', { 'varsIgnorePattern': '^(_|DB|initializeClient|saveData|loginAdmin|deleteClient|viewClientData|triggerWorkflow|checkSystemStatus)' }],
-    '@typescript-eslint/no-unused-vars': ['error', { 'varsIgnorePattern': '^(_|DB|initializeClient|saveData|loginAdmin|deleteClient|viewClientData|triggerWorkflow|checkSystemStatus)' }],
+    'no-unused-vars': ['error', { 'varsIgnorePattern': '^(_|DB|initializeClient|saveData|loginAdmin|deleteClient|viewClientData|triggerWorkflow|checkSystemStatus)', 'argsIgnorePattern': '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { 'varsIgnorePattern': '^(_|DB|initializeClient|saveData|loginAdmin|deleteClient|viewClientData|triggerWorkflow|checkSystemStatus)', 'argsIgnorePattern': '^_' }],
   },
   globals: {
     DB: 'readonly',

--- a/pages/manifest.v2.json
+++ b/pages/manifest.v2.json
@@ -1,0 +1,36 @@
+{
+  "manifest_version": 2,
+  "name": "ChronicleSync",
+  "version": "0.1.0",
+  "description": "Synchronize your browser history across devices securely",
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "32": "icons/icon32.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": [
+    "activeTab",
+    "tabs",
+    "history",
+    "storage"
+  ],
+  "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.chroniclesync.xyz/*",
+    "https://api-staging.chroniclesync.xyz/*"
+  ]
+}

--- a/pages/src/__tests__/popup.v2.test.tsx
+++ b/pages/src/__tests__/popup.v2.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Popup } from '../popup.v2';
+
+// Mock chrome.runtime.sendMessage
+// Mock only the parts of chrome API we use
+global.chrome = {
+  runtime: {
+    sendMessage: jest.fn()
+  }
+} as unknown as typeof chrome;
+
+describe('Popup Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders initial state correctly', () => {
+    render(<Popup />);
+    
+    expect(screen.getByText('ChronicleSync')).toBeInTheDocument();
+    expect(screen.getByText('Last sync: Never')).toBeInTheDocument();
+    expect(screen.getByText('Status: idle')).toBeInTheDocument();
+    expect(screen.getByText('Sync Now')).toBeEnabled();
+  });
+
+  it('handles successful sync', async () => {
+    (chrome.runtime.sendMessage as jest.Mock).mockResolvedValueOnce({ success: true });
+    
+    render(<Popup />);
+    
+    const syncButton = screen.getByText('Sync Now');
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+    
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'sync' });
+    expect(screen.getByText(/Last sync:/)).not.toHaveTextContent('Never');
+    expect(screen.getByText('Status: idle')).toBeInTheDocument();
+  });
+
+  it('handles sync failure', async () => {
+    (chrome.runtime.sendMessage as jest.Mock).mockResolvedValueOnce({ success: false });
+    
+    render(<Popup />);
+    
+    const syncButton = screen.getByText('Sync Now');
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+    
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'sync' });
+    expect(screen.getByText('Status: error')).toBeInTheDocument();
+  });
+
+  it('handles sync error', async () => {
+    (chrome.runtime.sendMessage as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+    
+    render(<Popup />);
+    
+    const syncButton = screen.getByText('Sync Now');
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+    
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'sync' });
+    expect(screen.getByText('Status: error')).toBeInTheDocument();
+  });
+
+  it('disables sync button while syncing', async () => {
+    // Use a promise that won't resolve immediately to keep the syncing state
+    let resolveSync: (_: { success: boolean }) => void;
+    const syncPromise = new Promise<{ success: boolean }>(resolve => {
+      resolveSync = resolve;
+    });
+    (chrome.runtime.sendMessage as jest.Mock).mockReturnValueOnce(syncPromise);
+    
+    render(<Popup />);
+    
+    const syncButton = screen.getByText('Sync Now');
+    await act(async () => {
+      fireEvent.click(syncButton);
+    });
+    
+    expect(screen.getByText('Syncing...')).toBeInTheDocument();
+    expect(screen.getByText('Syncing...')).toBeDisabled();
+    
+    // Resolve the sync
+    await act(async () => {
+      resolveSync!({ success: true });
+    });
+    
+    expect(screen.getByText('Sync Now')).toBeEnabled();
+  });
+});

--- a/pages/src/background.v2.ts
+++ b/pages/src/background.v2.ts
@@ -1,0 +1,55 @@
+// Simple in-memory queue for pending history items
+let pendingItems: Array<{url: string, title: string, timestamp: number}> = [];
+
+// Function to sync items with the server
+async function syncItems() {
+  if (pendingItems.length === 0) return;
+
+  const itemsToSync = [...pendingItems];
+  pendingItems = []; // Clear the queue
+
+  try {
+    const config = await chrome.storage.sync.get(['apiEndpoint']);
+    const endpoint = config.apiEndpoint || 'https://api.chroniclesync.xyz';
+
+    const response = await fetch(`${endpoint}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entries: itemsToSync })
+    });
+
+    if (!response.ok) {
+      // If sync fails, add items back to queue
+      pendingItems.push(...itemsToSync);
+      throw new Error(`Sync failed: ${response.statusText}`);
+    }
+  } catch (error) {
+    console.error('Sync error:', error);
+    // Items are already back in queue if sync failed
+  }
+}
+
+// Listen for history updates
+chrome.history.onVisited.addListener(async (result) => {
+  if (result.url) {
+    // Add to pending queue
+    pendingItems.push({
+      url: result.url,
+      title: result.title || '',
+      timestamp: new Date(result.lastVisitTime || Date.now()).getTime()
+    });
+
+    // Try to sync immediately
+    await syncItems();
+  }
+});
+
+// Listen for manual sync requests from popup
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'sync') {
+    syncItems()
+      .then(() => sendResponse({ success: true }))
+      .catch(error => sendResponse({ success: false, error: error.message }));
+    return true; // Will respond asynchronously
+  }
+});

--- a/pages/src/popup.v2.tsx
+++ b/pages/src/popup.v2.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
 
 function Popup() {
   const [status, setStatus] = useState<'idle' | 'syncing' | 'error'>('idle');
@@ -15,7 +15,7 @@ function Popup() {
       } else {
         setStatus('error');
       }
-    } catch (error) {
+    } catch {
       setStatus('error');
     }
   };
@@ -37,4 +37,8 @@ function Popup() {
   );
 }
 
-ReactDOM.render(<Popup />, document.getElementById('root'));
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<Popup />);
+}

--- a/pages/src/popup.v2.tsx
+++ b/pages/src/popup.v2.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+
+function Popup() {
+  const [status, setStatus] = useState<'idle' | 'syncing' | 'error'>('idle');
+  const [lastSync, setLastSync] = useState<string>('Never');
+
+  const handleManualSync = async () => {
+    setStatus('syncing');
+    try {
+      const response = await chrome.runtime.sendMessage({ type: 'sync' });
+      if (response.success) {
+        setStatus('idle');
+        setLastSync(new Date().toLocaleTimeString());
+      } else {
+        setStatus('error');
+      }
+    } catch (error) {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="popup">
+      <h2>ChronicleSync</h2>
+      <div className="status">
+        <p>Last sync: {lastSync}</p>
+        <p>Status: {status}</p>
+      </div>
+      <button 
+        onClick={handleManualSync}
+        disabled={status === 'syncing'}
+      >
+        {status === 'syncing' ? 'Syncing...' : 'Sync Now'}
+      </button>
+    </div>
+  );
+}
+
+ReactDOM.render(<Popup />, document.getElementById('root'));


### PR DESCRIPTION
This PR switches from a service worker to a non-persistent background page implementation for better iOS Safari compatibility.

Changes:
- Added manifest.v2.json with non-persistent background page configuration
- Created simplified background.v2.ts that only activates when needed
- Added popup.v2.tsx with manual sync support

Benefits:
- Better iOS Safari compatibility
- More efficient resource usage
- Simpler state management
- More predictable behavior across browsers