### PR TITLE
Separate Pages and Extension E2E Tests with Simplified Commands

### DIFF
--- a/pages/README.md
+++ b/pages/README.md
@@ -38,26 +38,17 @@ The pages component includes the frontend application and Chrome extension for C
 
 2. **End-to-End Tests**
    ```bash
-   # Run Pages deployment tests
-   npx playwright test --config=playwright.pages.config.ts
-
-   # Run Extension tests
-   npx playwright test --config=playwright.extension.config.ts
-
    # Run all E2E tests
-   npx playwright test --config=playwright.extension.config.ts && npx playwright test --config=playwright.pages.config.ts
+   npx playwright test
    ```
 
    The tests are split into two configurations:
    - `playwright.pages.config.ts`: Tests for the Pages deployment
    - `playwright.extension.config.ts`: Tests for the Chrome extension
 
-   You can also use the npm scripts:
-   ```bash
-   npm run test:e2e:pages     # Run Pages tests
-   npm run test:e2e:extension # Run Extension tests
-   npm run test:e2e          # Run all tests
-   ```
+   Each test file is automatically routed to the correct configuration based on its name:
+   - `*.pages.spec.ts` files use the Pages config
+   - `*.extension.spec.ts` files use the Extension config
 
 ### Project Structure
 

--- a/pages/README.md
+++ b/pages/README.md
@@ -36,12 +36,21 @@ The pages component includes the frontend application and Chrome extension for C
    npm test
    ```
 
-2. **PlayWright Tests**
+2. **End-to-End Tests**
    ```bash
-   npx playwright test
+   # Run Pages deployment tests
+   npm run test:e2e:pages
+
+   # Run Extension tests
+   npm run test:e2e:extension
+
+   # Run all E2E tests
+   npm run test:e2e
    ```
 
-   This runs Playwright tests for both the web interface and extension.
+   The tests are split into two configurations:
+   - `playwright.pages.config.ts`: Tests for the Pages deployment
+   - `playwright.extension.config.ts`: Tests for the Chrome extension
 
 ### Project Structure
 

--- a/pages/README.md
+++ b/pages/README.md
@@ -39,18 +39,25 @@ The pages component includes the frontend application and Chrome extension for C
 2. **End-to-End Tests**
    ```bash
    # Run Pages deployment tests
-   npm run test:e2e:pages
+   npx playwright test --config=playwright.pages.config.ts
 
    # Run Extension tests
-   npm run test:e2e:extension
+   npx playwright test --config=playwright.extension.config.ts
 
    # Run all E2E tests
-   npm run test:e2e
+   npx playwright test --config=playwright.extension.config.ts && npx playwright test --config=playwright.pages.config.ts
    ```
 
    The tests are split into two configurations:
    - `playwright.pages.config.ts`: Tests for the Pages deployment
    - `playwright.extension.config.ts`: Tests for the Chrome extension
+
+   You can also use the npm scripts:
+   ```bash
+   npm run test:e2e:pages     # Run Pages tests
+   npm run test:e2e:extension # Run Extension tests
+   npm run test:e2e          # Run all tests
+   ```
 
 ### Project Structure
 

--- a/pages/e2e/pages.spec.ts
+++ b/pages/e2e/pages.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ChronicleSync Pages', () => {
+  test('should load the main page', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /ChronicleSync/i })).toBeVisible();
+  });
+
+  test('should show search interface', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByPlaceholder(/Search history/i)).toBeVisible();
+  });
+
+  test('should show empty state when no history', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(/No history items found/i)).toBeVisible();
+  });
+
+  test('should have working navigation', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: /Dashboard/i }).click();
+    await expect(page.url()).toContain('/dashboard');
+  });
+});

--- a/pages/package-lock.json
+++ b/pages/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.0",
         "@babel/preset-env": "^7.22.20",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.50.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^14.5.2",
@@ -3916,13 +3916,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10561,13 +10561,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10580,9 +10580,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/pages/package.json
+++ b/pages/package.json
@@ -5,15 +5,18 @@
   "scripts": {
     "dev": "vite",
     "dev:extension": "BUILD_TARGET=extension vite",
-    "build:web": "tsc && vite build",
+    "build:web": "tsc && BUILD_TARGET=pages vite build",
     "build:extension": "tsc && BUILD_TARGET=extension BUILD_ENTRY=popup vite build && BUILD_TARGET=extension BUILD_ENTRY=background vite build && mkdir -p dist/extension/icons && cp manifest.json popup.html dist/extension/ && cp icons/* dist/extension/icons/",
+    "build:pages": "tsc && BUILD_TARGET=pages vite build",
     "preview": "vite preview",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:pages": "playwright test e2e/pages.spec.ts",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\" --fix",
-    "deploy": "wrangler pages deploy dist --project-name chroniclesync-pages"
+    "deploy": "npm run build:pages && wrangler pages deploy dist --project-name chroniclesync-pages"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/pages/package.json
+++ b/pages/package.json
@@ -12,9 +12,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:e2e:extension": "npx playwright test --config=playwright.extension.config.ts",
-    "test:e2e:pages": "npx playwright test --config=playwright.pages.config.ts",
-    "test:e2e": "npx playwright test --config=playwright.extension.config.ts && npx playwright test --config=playwright.pages.config.ts",
+    "test:e2e": "npx playwright test",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\" --fix",
     "deploy": "npm run build:pages && wrangler pages deploy dist --project-name chroniclesync-pages"

--- a/pages/package.json
+++ b/pages/package.json
@@ -12,9 +12,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:e2e:extension": "playwright test --config=playwright.extension.config.ts",
-    "test:e2e:pages": "playwright test --config=playwright.pages.config.ts",
-    "test:e2e": "npm run test:e2e:extension && npm run test:e2e:pages",
+    "test:e2e:extension": "npx playwright test --config=playwright.extension.config.ts",
+    "test:e2e:pages": "npx playwright test --config=playwright.pages.config.ts",
+    "test:e2e": "npx playwright test --config=playwright.extension.config.ts && npx playwright test --config=playwright.pages.config.ts",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\" --fix",
     "deploy": "npm run build:pages && wrangler pages deploy dist --project-name chroniclesync-pages"

--- a/pages/package.json
+++ b/pages/package.json
@@ -12,8 +12,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:e2e": "playwright test",
-    "test:e2e:pages": "playwright test e2e/pages.spec.ts",
+    "test:e2e:extension": "playwright test --config=playwright.extension.config.ts",
+    "test:e2e:pages": "playwright test --config=playwright.pages.config.ts",
+    "test:e2e": "npm run test:e2e:extension && npm run test:e2e:pages",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.{ts,tsx}\" --fix",
     "deploy": "npm run build:pages && wrangler pages deploy dist --project-name chroniclesync-pages"
@@ -25,7 +26,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.0",
     "@babel/preset-env": "^7.22.20",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.50.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.5.2",

--- a/pages/playwright.config.ts
+++ b/pages/playwright.config.ts
@@ -27,25 +27,40 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'extension',
+      testMatch: /extension\.spec\.ts/,
       use: {
         launchOptions: {
           args: [
             '--no-sandbox',
             '--disable-setuid-sandbox',
-            '--enable-automation',  // Required for extension testing
-            '--allow-insecure-localhost',  // Allow local testing
-            '--disable-background-timer-throttling',  // Prevent background throttling
-            '--disable-backgrounding-occluded-windows',  // Keep background pages active
-            '--disable-renderer-backgrounding',  // Keep renderers active
+            '--enable-automation',
+            '--allow-insecure-localhost',
+            '--disable-background-timer-throttling',
+            '--disable-backgrounding-occluded-windows',
+            '--disable-renderer-backgrounding',
             `--disable-extensions-except=${paths.extensionDist}`,
             `--load-extension=${paths.extensionDist}`,
           ],
-          timeout: 30000,  // Increase launch timeout
+          timeout: 30000,
         },
         contextOptions: {
-          reducedMotion: 'reduce',  // Reduce animations
-          serviceWorkers: 'allow',  // Explicitly allow service workers
+          reducedMotion: 'reduce',
+          serviceWorkers: 'allow',
+        },
+      },
+    },
+    {
+      name: 'pages',
+      testMatch: /pages\.spec\.ts/,
+      use: {
+        baseURL: 'http://localhost:53374',
+        launchOptions: {
+          args: [
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--allow-insecure-localhost',
+          ],
         },
       },
     },
@@ -54,4 +69,12 @@ export default defineConfig({
   workers: 1,  // Consistent, predictable test execution
   reporter: process.env.CI ? 'github' : 'list',  // Better output formatting for each environment
   globalSetup: './e2e/global-setup.ts',
+  webServer: [
+    {
+      command: 'npm run dev',
+      url: 'http://localhost:53374',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120000,
+    },
+  ],
 });

--- a/pages/playwright.extension.config.ts
+++ b/pages/playwright.extension.config.ts
@@ -50,31 +50,9 @@ export default defineConfig({
         },
       },
     },
-    {
-      name: 'pages',
-      testMatch: /pages\.spec\.ts/,
-      use: {
-        baseURL: 'http://localhost:53374',
-        launchOptions: {
-          args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
-            '--allow-insecure-localhost',
-          ],
-        },
-      },
-    },
   ],
   forbidOnly: true,  // Always prevent .only tests
   workers: 1,  // Consistent, predictable test execution
   reporter: process.env.CI ? 'github' : 'list',  // Better output formatting for each environment
   globalSetup: './e2e/global-setup.ts',
-  webServer: [
-    {
-      command: 'npm run dev',
-      url: 'http://localhost:53374',
-      reuseExistingServer: !process.env.CI,
-      timeout: 120000,
-    },
-  ],
 });

--- a/pages/playwright.pages.config.ts
+++ b/pages/playwright.pages.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /pages\.spec\.ts/,
+  use: {
+    baseURL: 'http://localhost:53374',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:53374',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  reporter: process.env.CI ? 'github' : 'list',
+  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 2 : 0,
+  forbidOnly: !!process.env.CI,
+});

--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ command }) => {
   const buildEntry = process.env.BUILD_ENTRY;
 
   if (!isExtension) {
+    const isPages = process.env.BUILD_TARGET === 'pages';
     return {
       plugins: [react()],
       build: {
@@ -19,11 +20,19 @@ export default defineConfig(({ command }) => {
             format: 'es' as ModuleFormat,
             entryFileNames: '[name].[hash].js',
             assetFileNames: 'assets/[name].[ext]'
-          }
+          },
+          external: isPages ? [] : ['chrome']
         }
       },
+      define: {
+        'process.env.IS_PAGES': JSON.stringify(isPages)
+      },
       server: {
-        port: server.port
+        port: server.port,
+        host: '0.0.0.0',
+        headers: {
+          'Access-Control-Allow-Origin': '*'
+        }
       }
     };
   }


### PR DESCRIPTION
This PR separates the Playwright configurations for Pages and Extension testing, making it easier to maintain and run tests for each component independently.

Changes:
- Created separate Playwright configs:
  - `playwright.pages.config.ts` for Pages deployment
  - `playwright.extension.config.ts` for Chrome extension
- Added Pages-specific e2e tests
- Updated GitHub Actions workflow to handle both test suites
- Updated documentation in main README and Pages README
- Simplified test commands to use `npx playwright test` everywhere

Testing:
- All tests can be run with `npx playwright test`
- Tests are automatically routed to the correct config based on their filename:
  - `*.pages.spec.ts` files use the Pages config
  - `*.extension.spec.ts` files use the Extension config