### PR TITLE
Add extension settings and configuration

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/extension/config.js
+++ b/extension/config.js
@@ -1,0 +1,34 @@
+const defaultConfig = {
+  apiEndpoint: 'https://chroniclesync.pages.dev',
+  clientId: 'extension-default'
+};
+
+// Load configuration from storage or use defaults
+async function getConfig() {
+  try {
+    const result = await chrome.storage.sync.get(['apiEndpoint', 'clientId']);
+    return {
+      apiEndpoint: result.apiEndpoint || defaultConfig.apiEndpoint,
+      clientId: result.clientId || defaultConfig.clientId
+    };
+  } catch (error) {
+    console.error('Error loading config:', error);
+    return defaultConfig;
+  }
+}
+
+// Save configuration to storage
+async function saveConfig(config) {
+  try {
+    await chrome.storage.sync.set({
+      apiEndpoint: config.apiEndpoint,
+      clientId: config.clientId
+    });
+    return true;
+  } catch (error) {
+    console.error('Error saving config:', error);
+    return false;
+  }
+}
+
+export { getConfig, saveConfig, defaultConfig };

--- a/extension/config.js
+++ b/extension/config.js
@@ -1,5 +1,6 @@
 const defaultConfig = {
-  apiEndpoint: 'https://chroniclesync.pages.dev',
+  apiEndpoint: 'https://api.chroniclesync.xyz',  // Worker API endpoint
+  pagesUrl: 'https://chroniclesync.pages.dev',   // Pages UI endpoint
   clientId: 'extension-default'
 };
 

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,10 @@
+body {
+  width: 400px;
+  height: 600px;
+  margin: 0;
+  padding: 0;
+}
+#root {
+  width: 100%;
+  height: 100%;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -7,8 +7,19 @@
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <iframe id="pages-frame" style="width: 100%; height: 100%; border: none;"></iframe>
+  </div>
   <link rel="stylesheet" href="dist/assets/styles.css">
   <script src="dist/popup.js"></script>
+  <script>
+    // Load the pages UI in the iframe
+    async function loadPagesUI() {
+      const { pagesUrl } = await chrome.storage.sync.get(['pagesUrl']);
+      const iframe = document.getElementById('pages-frame');
+      iframe.src = pagesUrl || 'https://chroniclesync.pages.dev';
+    }
+    loadPagesUI();
+  </script>
 </body>
 </html>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -4,18 +4,7 @@
   <title>ChronicleSync Extension</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      width: 400px;
-      height: 600px;
-      margin: 0;
-      padding: 0;
-    }
-    #root {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
+  <link rel="stylesheet" href="popup.css">
 </head>
 <body>
   <div id="root"></div>

--- a/extension/settings.css
+++ b/extension/settings.css
@@ -1,0 +1,56 @@
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.button-group {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.button-group button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.button-group button[type="submit"] {
+  background-color: #4CAF50;
+  color: white;
+}
+
+.button-group button[type="button"] {
+  background-color: #f44336;
+  color: white;
+}
+
+.message {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.message.success {
+  background-color: #dff0d8;
+  color: #3c763d;
+}
+
+.message.error {
+  background-color: #f2dede;
+  color: #a94442;
+}

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -15,6 +15,7 @@ class Settings {
     const form = event.target;
     const newConfig = {
       apiEndpoint: form.apiEndpoint.value.trim(),
+      pagesUrl: form.pagesUrl.value.trim(),
       clientId: form.clientId.value.trim()
     };
     
@@ -53,9 +54,15 @@ class Settings {
     container.innerHTML = `
       <form id="settings-form">
         <div class="form-group">
-          <label for="apiEndpoint">API Endpoint:</label>
+          <label for="apiEndpoint">Worker API Endpoint:</label>
           <input type="url" id="apiEndpoint" name="apiEndpoint" 
                  value="${this.config.apiEndpoint}" required
+                 placeholder="https://api.chroniclesync.xyz">
+        </div>
+        <div class="form-group">
+          <label for="pagesUrl">Pages UI URL:</label>
+          <input type="url" id="pagesUrl" name="pagesUrl" 
+                 value="${this.config.pagesUrl}" required
                  placeholder="https://chroniclesync.pages.dev">
         </div>
         <div class="form-group">

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,0 +1,84 @@
+import { getConfig, saveConfig, defaultConfig } from './config.js';
+
+class Settings {
+  constructor() {
+    this.config = null;
+  }
+
+  async init() {
+    this.config = await getConfig();
+    this.render();
+  }
+
+  async handleSave(event) {
+    event.preventDefault();
+    const form = event.target;
+    const newConfig = {
+      apiEndpoint: form.apiEndpoint.value.trim(),
+      clientId: form.clientId.value.trim()
+    };
+    
+    if (await saveConfig(newConfig)) {
+      this.config = newConfig;
+      this.showMessage('Settings saved successfully!', 'success');
+    } else {
+      this.showMessage('Failed to save settings.', 'error');
+    }
+  }
+
+  handleReset() {
+    if (confirm('Reset to default settings?')) {
+      saveConfig(defaultConfig).then(() => {
+        this.config = defaultConfig;
+        this.render();
+        this.showMessage('Settings reset to defaults.', 'success');
+      });
+    }
+  }
+
+  showMessage(message, type) {
+    const messageEl = document.getElementById('settings-message');
+    messageEl.textContent = message;
+    messageEl.className = `message ${type}`;
+    setTimeout(() => {
+      messageEl.textContent = '';
+      messageEl.className = 'message';
+    }, 3000);
+  }
+
+  render() {
+    const container = document.getElementById('settings-container');
+    if (!container) return;
+
+    container.innerHTML = `
+      <form id="settings-form">
+        <div class="form-group">
+          <label for="apiEndpoint">API Endpoint:</label>
+          <input type="url" id="apiEndpoint" name="apiEndpoint" 
+                 value="${this.config.apiEndpoint}" required
+                 placeholder="https://chroniclesync.pages.dev">
+        </div>
+        <div class="form-group">
+          <label for="clientId">Client ID:</label>
+          <input type="text" id="clientId" name="clientId" 
+                 value="${this.config.clientId}" required
+                 placeholder="extension-default">
+        </div>
+        <div class="button-group">
+          <button type="submit">Save Settings</button>
+          <button type="button" id="reset-settings">Reset to Defaults</button>
+        </div>
+        <div id="settings-message" class="message"></div>
+      </form>
+    `;
+
+    // Add event listeners
+    const form = document.getElementById('settings-form');
+    const resetButton = document.getElementById('reset-settings');
+    
+    form.addEventListener('submit', (e) => this.handleSave(e));
+    resetButton.addEventListener('click', () => this.handleReset());
+  }
+}
+
+export default Settings;


### PR DESCRIPTION
This PR adds a configuration system and settings UI to the Chrome extension:

- Break out popup CSS into separate file for better organization
- Add configuration system for API endpoint and client ID using chrome.storage.sync
- Add settings UI component with form to configure API endpoint and client ID
- Add styles for settings UI
- Set default API endpoint to chroniclesync.pages.dev
- Add .gitignore for test results

The extension now allows users to:
- Use default API endpoint (chroniclesync.pages.dev) and client ID
- Configure custom API endpoint and client ID
- Persist settings across browser sessions
- Reset to default settings if needed