### PR TITLE
Add unit tests for Settings component

### DIFF
--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -1,0 +1,104 @@
+import Settings from '../settings.js';
+import { getConfig, saveConfig, defaultConfig } from '../config.js';
+
+jest.mock('../config.js');
+
+describe('Settings', () => {
+  let settings;
+  let mockContainer;
+
+  beforeEach(() => {
+    settings = new Settings();
+    mockContainer = document.createElement('div');
+    mockContainer.id = 'settings-container';
+    document.body.appendChild(mockContainer);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.clearAllMocks();
+  });
+
+  test('initializes with null config', () => {
+    expect(settings.config).toBeNull();
+  });
+
+  test('init loads and renders config', async () => {
+    const mockConfig = {
+      apiEndpoint: 'http://test-api.com',
+      pagesUrl: 'http://test-pages.com',
+      clientId: 'test-client'
+    };
+    getConfig.mockResolvedValue(mockConfig);
+
+    await settings.init();
+
+    expect(settings.config).toEqual(mockConfig);
+    expect(document.getElementById('apiEndpoint').value).toBe(mockConfig.apiEndpoint);
+    expect(document.getElementById('pagesUrl').value).toBe(mockConfig.pagesUrl);
+    expect(document.getElementById('clientId').value).toBe(mockConfig.clientId);
+  });
+
+  test('handleSave updates config and shows success message', async () => {
+    const newConfig = {
+      apiEndpoint: 'http://new-api.com',
+      pagesUrl: 'http://new-pages.com',
+      clientId: 'new-client'
+    };
+
+    settings.config = { ...defaultConfig };
+    saveConfig.mockResolvedValue(true);
+    
+    const form = document.createElement('form');
+    const apiEndpoint = document.createElement('input');
+    apiEndpoint.id = 'apiEndpoint';
+    apiEndpoint.name = 'apiEndpoint';
+    apiEndpoint.value = newConfig.apiEndpoint;
+    form.appendChild(apiEndpoint);
+
+    const pagesUrl = document.createElement('input');
+    pagesUrl.id = 'pagesUrl';
+    pagesUrl.name = 'pagesUrl';
+    pagesUrl.value = newConfig.pagesUrl;
+    form.appendChild(pagesUrl);
+
+    const clientId = document.createElement('input');
+    clientId.id = 'clientId';
+    clientId.name = 'clientId';
+    clientId.value = newConfig.clientId;
+    form.appendChild(clientId);
+
+    // Add message element required by showMessage
+    const messageEl = document.createElement('div');
+    messageEl.id = 'settings-message';
+    document.body.appendChild(messageEl);
+
+    const mockEvent = {
+      preventDefault: jest.fn(),
+      target: form
+    };
+
+    await settings.handleSave(mockEvent);
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(saveConfig).toHaveBeenCalledWith(newConfig);
+    expect(settings.config).toEqual(newConfig);
+  });
+
+  test('handleReset resets to default config when confirmed', async () => {
+    global.confirm = jest.fn(() => true);
+    saveConfig.mockResolvedValue(true);
+    
+    settings.config = {
+      apiEndpoint: 'http://custom-api.com',
+      pagesUrl: 'http://custom-pages.com',
+      clientId: 'custom-client'
+    };
+
+    await settings.handleReset();
+
+    expect(global.confirm).toHaveBeenCalled();
+    expect(saveConfig).toHaveBeenCalledWith(defaultConfig);
+    expect(settings.config).toEqual(defaultConfig);
+  });
+});

--- a/extension/babel.config.js
+++ b/extension/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+  ],
+};

--- a/extension/jest.config.extension.js
+++ b/extension/jest.config.extension.js
@@ -15,8 +15,8 @@ module.exports = {
       tabs: {},
       storage: {
         local: {
-          get: jest.fn(),
-          set: jest.fn()
+          get: () => {},
+          set: () => {}
         }
       }
     }

--- a/extension/jest.config.js
+++ b/extension/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
+  },
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  collectCoverageFrom: [
+    '**/*.{js,jsx,ts,tsx}',
+    '!**/node_modules/**',
+    '!**/dist/**',
+  ],
+};

--- a/extension/jest.setup.js
+++ b/extension/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -14,9 +14,9 @@ class Settings {
     event.preventDefault();
     const form = event.target;
     const newConfig = {
-      apiEndpoint: form.apiEndpoint.value.trim(),
-      pagesUrl: form.pagesUrl.value.trim(),
-      clientId: form.clientId.value.trim()
+      apiEndpoint: form.elements.apiEndpoint.value.trim(),
+      pagesUrl: form.elements.pagesUrl.value.trim(),
+      clientId: form.elements.clientId.value.trim()
     };
     
     if (await saveConfig(newConfig)) {


### PR DESCRIPTION
This PR adds unit tests for the Settings component in the extension directory. Changes include:

- Added Jest configuration files
- Created basic unit tests for Settings component
- Fixed form handling in settings.js
- Added test coverage for initialization, saving, and resetting settings

All tests are passing and verify the core functionality of the Settings component.