### PR TITLE
Fix extension tests and build

### DIFF
--- a/extension/e2e/utils/extension.ts
+++ b/extension/e2e/utils/extension.ts
@@ -1,4 +1,4 @@
-import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import { test as base, chromium, type BrowserContext, type TestInfo } from '@playwright/test';
 import { paths } from '../../src/config';
 
 export type TestFixtures = {
@@ -7,7 +7,7 @@ export type TestFixtures = {
 };
 
 export const test = base.extend<TestFixtures>({
-  context: async (_obj, testInfo) => {
+  context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
       headless: false,
       args: [
@@ -15,10 +15,10 @@ export const test = base.extend<TestFixtures>({
         `--load-extension=${paths.extension}`,
       ],
     });
-    testInfo.context = context;
+    await use(context);
     await context.close();
   },
-  extensionId: async ({ context }, testInfo) => {
+  extensionId: async ({ context }, use) => {
     // Open a page to trigger extension loading
     const page = await context.newPage();
     await page.goto('https://example.com');
@@ -30,7 +30,7 @@ export const test = base.extend<TestFixtures>({
       workers[0].url().split('/')[2] : 
       'unknown-extension-id';
 
-    testInfo.extensionId = extensionId;
+    await use(extensionId);
     await page.close();
   },
 });

--- a/extension/e2e/utils/extension.ts
+++ b/extension/e2e/utils/extension.ts
@@ -1,4 +1,5 @@
-import { test as base, chromium, type BrowserContext, type TestInfo } from '@playwright/test';
+/* eslint-disable react-hooks/rules-of-hooks */
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
 import { paths } from '../../src/config';
 
 export type TestFixtures = {
@@ -7,7 +8,7 @@ export type TestFixtures = {
 };
 
 export const test = base.extend<TestFixtures>({
-  context: async ({}, use) => {
+  context: async (_obj, use) => {
     const context = await chromium.launchPersistentContext('', {
       headless: false,
       args: [


### PR DESCRIPTION
This PR fixes the extension tests and build process:

### Changes
- Fixed TypeScript errors in e2e test fixtures
  - Updated test fixtures to use Playwright fixture pattern correctly
  - Added ESLint disable for react-hooks/rules-of-hooks in test fixtures
- Fixed all linting issues
- Successfully built the extension

### Verification
- ✅ ESLint checks passed
- ✅ TypeScript compilation passed
- ✅ Extension built successfully
  - popup.css: 0.08 KB
  - background.js: 0.16 KB
  - popup.js: 10.20 KB
  - client bundle: 176.18 KB