### PR TITLE
Fix pages build to include index.html

### DIFF
--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -8,12 +8,11 @@ export default defineConfig({
     outDir: paths.webDist,
     emptyOutDir: true,
     rollupOptions: {
-      input: 'src/index.tsx',
       output: {
         format: 'es',
-        entryFileNames: '[name].js',
-        assetFileNames: 'assets/[name].[ext]',
-        inlineDynamicImports: false
+        entryFileNames: 'assets/[name].[hash].js',
+        chunkFileNames: 'assets/[name].[hash].js',
+        assetFileNames: 'assets/[name].[hash].[ext]'
       }
     }
   },


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment issue by correcting the Vite build configuration.

Changes:
- Removed custom `input` configuration that was causing index.html to be omitted
- Updated output configuration to use proper hashing for cache busting
- Ensures index.html is included in the build output

This should fix the issue where chroniclesync.xyz was not deploying correctly.