### PR TITLE
Add history sync feature (#267)

### DIFF
--- a/extension/__tests__/history.test.js
+++ b/extension/__tests__/history.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('History Sync', () => {
+  let mockChrome;
+  let mockFetch;
+
+  beforeEach(() => {
+    // Mock chrome API
+    mockChrome = {
+      history: {
+        search: vi.fn()
+      },
+      storage: {
+        sync: {
+          get: vi.fn()
+        }
+      },
+      tabs: {
+        onUpdated: {
+          addListener: vi.fn()
+        }
+      },
+      runtime: {
+        sendMessage: vi.fn()
+      }
+    };
+    global.chrome = mockChrome;
+
+    // Mock fetch
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+  });
+
+  it('should sync history data successfully', async () => {
+    const mockHistoryItems = [
+      {
+        url: 'https://example.com',
+        title: 'Example Site',
+        visitCount: 5,
+        lastVisitTime: Date.now()
+      }
+    ];
+
+    const mockConfig = {
+      apiEndpoint: 'https://api.chroniclesync.xyz',
+      clientId: 'test-client'
+    };
+
+    // Setup mocks
+    vi.mocked(mockChrome.history.search).mockResolvedValue(mockHistoryItems);
+    vi.mocked(mockChrome.storage.sync.get).mockResolvedValue(mockConfig);
+    vi.mocked(mockFetch).mockResolvedValue({ ok: true });
+
+    // Import and test the syncHistory function
+    const { syncHistory } = await import('../background.js');
+    const result = await syncHistory(mockConfig);
+
+    // Verify the history search was called
+    expect(mockChrome.history.search).toHaveBeenCalledWith({
+      text: '',
+      startTime: expect.any(Number),
+      maxResults: 5000
+    });
+
+    // Verify the API call was made correctly
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${mockConfig.apiEndpoint}/api/sync`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Client-ID': mockConfig.clientId
+        },
+        body: JSON.stringify({
+          type: 'history',
+          data: mockHistoryItems
+        })
+      }
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const mockHistoryItems = [
+      {
+        url: 'https://example.com',
+        title: 'Example Site',
+        visitCount: 1,
+        lastVisitTime: Date.now()
+      }
+    ];
+
+    const mockConfig = {
+      apiEndpoint: 'https://api.chroniclesync.xyz',
+      clientId: 'test-client'
+    };
+
+    // Setup mocks
+    vi.mocked(mockChrome.history.search).mockResolvedValue(mockHistoryItems);
+    vi.mocked(mockChrome.storage.sync.get).mockResolvedValue(mockConfig);
+    vi.mocked(mockFetch).mockResolvedValue({ ok: false, status: 500 });
+
+    // Import and test the syncHistory function
+    const { syncHistory } = await import('../background.js');
+    const result = await syncHistory(mockConfig);
+
+    expect(result).toBe(false);
+  });
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,13 +1,65 @@
-function logToBackground(message) {
-  chrome.runtime.getBackgroundPage((backgroundPage) => {
-    if (backgroundPage) {
-      backgroundPage.console.debug(message);
+import { getConfig } from './config.js';
+
+export async function syncHistory(config) {
+  try {
+    const oneWeekAgo = new Date().getTime() - (7 * 24 * 60 * 60 * 1000);
+    const historyItems = await chrome.history.search({
+      text: '',
+      startTime: oneWeekAgo,
+      maxResults: 5000
+    });
+
+    const historyData = historyItems.map(item => ({
+      url: item.url,
+      title: item.title,
+      visitCount: item.visitCount,
+      lastVisitTime: item.lastVisitTime
+    }));
+
+    const response = await fetch(`${config.apiEndpoint}/api/sync`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Client-ID': config.clientId
+      },
+      body: JSON.stringify({
+        type: 'history',
+        data: historyData
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
     }
-  });
+
+    return true;
+  } catch (error) {
+    // Log error to extension's error reporting system
+    chrome.runtime.sendMessage({
+      type: 'error',
+      message: `Error syncing history: ${error.message}`
+    });
+    return false;
+  }
 }
 
-chrome.tabs.onUpdated.addListener((_tabId, changeInfo, _tab) => {
+// Sync history every hour
+async function setupHistorySync() {
+  const config = await getConfig();
+  await syncHistory(config);
+  setInterval(async () => {
+    const updatedConfig = await getConfig();
+    await syncHistory(updatedConfig);
+  }, 60 * 60 * 1000);
+}
+
+// Start history sync when extension loads
+setupHistorySync();
+
+// Listen for tab updates to track new history items
+chrome.tabs.onUpdated.addListener(async (_tabId, changeInfo, _tab) => {
   if (changeInfo.url) {
-    logToBackground(`Navigation to: ${changeInfo.url}`);
+    const config = await getConfig();
+    await syncHistory(config);
   }
 });

--- a/extension/e2e/history.spec.ts
+++ b/extension/e2e/history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { chromium, Browser, BrowserContext } from 'playwright';
+import { chromium, BrowserContext } from 'playwright';
 import path from 'path';
 
 test.describe('History Sync Feature', () => {

--- a/extension/e2e/history.spec.ts
+++ b/extension/e2e/history.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { chromium } from 'playwright';
+import path from 'path';
+
+test.describe('History Sync Feature', () => {
+  test('should sync history and display in pages UI', async () => {
+    // Load the extension
+    const pathToExtension = path.join(__dirname, '../');
+    const userDataDir = '/tmp/test-user-data-dir';
+    
+    const browser = await chromium.launchPersistentContext(userDataDir, {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+    });
+
+    // Create a new page
+    const page = await browser.newPage();
+
+    // Navigate to some test pages to create history
+    await page.goto('https://example.com');
+    await page.goto('https://test.com');
+
+    // Open extension popup
+    const extensionId = await getExtensionId(browser);
+    const popupPage = await browser.newPage();
+    await popupPage.goto(`chrome-extension://${extensionId}/popup.html`);
+
+    // Set client ID in settings
+    await popupPage.click('text=Settings');
+    await popupPage.fill('#clientId', 'test-client-id');
+    await popupPage.click('text=Save Settings');
+
+    // Verify success message
+    const message = await popupPage.textContent('.message');
+    expect(message).toContain('Settings saved successfully');
+
+    // Navigate to pages UI
+    const pagesUrl = await popupPage.getAttribute('#pagesUrl', 'value');
+    await page.goto(pagesUrl);
+
+    // Take screenshot of history view
+    await page.screenshot({ path: 'history-view.png' });
+
+    // Verify history entries are present
+    const historyEntries = await page.$$('.history-entry');
+    expect(historyEntries.length).toBeGreaterThan(0);
+
+    await browser.close();
+  });
+});
+
+async function getExtensionId(context) {
+  const page = await context.newPage();
+  await page.goto('chrome://extensions');
+  const devMode = await page.$('text=Developer mode');
+  if (devMode) await devMode.click();
+  const id = await page.evaluate(() => {
+    const extensions = document.querySelector('extensions-manager').shadowRoot
+      .querySelector('extensions-item-list').shadowRoot
+      .querySelectorAll('extensions-item');
+    for (const extension of extensions) {
+      if (extension.shadowRoot.querySelector('[title="ChronicleSync Extension"]')) {
+        return extension.id;
+      }
+    }
+  });
+  await page.close();
+  return id;
+}

--- a/extension/e2e/history.spec.ts
+++ b/extension/e2e/history.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { chromium, BrowserContext } from 'playwright';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 test.describe('History Sync Feature', () => {
   test('should sync history and display in pages UI', async () => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,6 +3,7 @@
   "name": "ChronicleSync Extension",
   "version": "1.0",
   "description": "ChronicleSync Chrome Extension - Sync your browser history",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhm3X7qutsrskke84ltbxhvBp24tFbGWPddX2K4yI+TXQYhf+eQXp1r1wfNFU1YMbHhXTVkXmxPHYzxz8eXrARHD9Rz3K+KKYgC+NFPg0K8YsejRnROqUQLpqE5dFpKFS9ZPGxcBXnqyqserXcE+bBk3pxl2V0kz6bXh8m91sxA==",
   "action": {
     "default_popup": "popup.html"
   },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ChronicleSync Extension",
   "version": "1.0",
-  "description": "ChronicleSync Chrome Extension",
+  "description": "ChronicleSync Chrome Extension - Sync your browser history",
   "action": {
     "default_popup": "popup.html"
   },
@@ -20,6 +20,7 @@
   "host_permissions": [
     "http://localhost:*/*",
     "https://api.chroniclesync.xyz/*",
-    "https://api-staging.chroniclesync.xyz/*"
+    "https://api-staging.chroniclesync.xyz/*",
+    "https://chroniclesync.pages.dev/*"
   ]
 }


### PR DESCRIPTION
Implements issue #267 to add browser history syncing feature.

### Changes
- Add history syncing functionality that uses existing worker API
- Add unit tests and e2e tests for history feature
- Update manifest.json with required permissions
- No changes to worker or pages code required

### Testing
- Added unit tests for history syncing
- Added e2e tests with Playwright
- All tests passing
- Fixed TypeScript and linting issues

### Notes
- Uses existing worker API without modifications
- Syncs history data every hour and on tab updates
- Respects client ID configuration
- Uses existing pages UI for viewing history

### Recent Updates
- Fixed __dirname not defined error in e2e tests
- Fixed TypeScript errors and improved type safety
- All linting issues resolved