### PR TITLE
Add settings workflow with auto-loading pages

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,3 +1,5 @@
+import { getConfig } from './config.js';
+
 function logToBackground(message) {
   chrome.runtime.getBackgroundPage((backgroundPage) => {
     if (backgroundPage) {
@@ -5,6 +7,26 @@ function logToBackground(message) {
     }
   });
 }
+
+async function openSettingsPage() {
+  const settingsUrl = chrome.runtime.getURL('settings.html');
+  await chrome.windows.create({
+    url: settingsUrl,
+    type: 'popup',
+    width: 500,
+    height: 600
+  });
+}
+
+async function checkFirstRun() {
+  const config = await getConfig();
+  if (!config || !config.apiEndpoint || !config.clientId) {
+    await openSettingsPage();
+  }
+}
+
+// Check settings on extension install/update
+chrome.runtime.onInstalled.addListener(checkFirstRun);
 
 chrome.tabs.onUpdated.addListener((_tabId, changeInfo, _tab) => {
   if (changeInfo.url) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,5 +21,9 @@
     "http://localhost:*/*",
     "https://api.chroniclesync.xyz/*",
     "https://api-staging.chroniclesync.xyz/*"
-  ]
+  ],
+  "web_accessible_resources": [{
+    "resources": ["settings.html"],
+    "matches": ["<all_urls>"]
+  }]
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -3,8 +3,64 @@ body {
   height: 600px;
   margin: 0;
   padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
 #root {
   width: 100%;
   height: 100%;
+}
+
+.app {
+  padding: 20px;
+}
+
+h1 {
+  margin: 0 0 20px;
+  text-align: center;
+  color: #333;
+}
+
+.status {
+  margin: 20px 0;
+  padding: 10px;
+  background: #f5f5f5;
+  border-radius: 4px;
+}
+
+.status p {
+  margin: 5px 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+button {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button:not(.settings-btn) {
+  background-color: #4CAF50;
+  color: white;
+}
+
+.settings-btn {
+  background-color: #2196F3;
+  color: white;
 }

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ChronicleSync Settings</title>
+  <link rel="stylesheet" href="settings.css">
+</head>
+<body>
+  <div id="settings-container"></div>
+  <script type="module">
+    import Settings from './settings.js';
+    const settings = new Settings();
+    settings.init();
+  </script>
+</body>
+</html>

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -1,18 +1,34 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import '../popup.css';
+import { getConfig } from '../config.js';
 
 export function App() {
   const [initialized, setInitialized] = useState(false);
   const [clientId, setClientId] = useState('');
+  const [config, setConfig] = useState(null);
 
-  const handleInitialize = () => {
-    if (clientId) {
-      setInitialized(true);
-    }
-  };
+  useEffect(() => {
+    const loadConfig = async () => {
+      const cfg = await getConfig();
+      setConfig(cfg);
+      setClientId(cfg.clientId);
+      setInitialized(!!cfg.clientId);
+    };
+    loadConfig();
+  }, []);
 
   const handleSync = () => {
     alert('Sync successful');
+  };
+
+  const openSettings = () => {
+    const settingsUrl = chrome.runtime.getURL('settings.html');
+    chrome.windows.create({
+      url: settingsUrl,
+      type: 'popup',
+      width: 500,
+      height: 600
+    });
   };
 
   return (
@@ -20,20 +36,22 @@ export function App() {
       <h1>ChronicleSync</h1>
       <div id="adminLogin">
         <h2>Admin Login</h2>
-        <form>
-          <input
-            type="text"
-            id="clientId"
-            placeholder="Client ID"
-            value={clientId}
-            onChange={(e) => setClientId(e.target.value)}
-          />
-          {!initialized ? (
-            <button type="button" onClick={handleInitialize}>Initialize</button>
-          ) : (
-            <button type="button" onClick={handleSync}>Sync with Server</button>
+        <div className="status">
+          {config && (
+            <div>
+              <p>Client ID: {config.clientId}</p>
+              <p>API: {config.apiEndpoint}</p>
+            </div>
           )}
-        </form>
+        </div>
+        <div className="actions">
+          <button type="button" onClick={handleSync} disabled={!initialized}>
+            Sync with Server
+          </button>
+          <button type="button" onClick={openSettings} className="settings-btn">
+            Settings
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Resolves #278

This PR implements the settings workflow with the following features:

- Created a dedicated settings.html page that opens in a popup window
- Added settings page to manifest.json as a web accessible resource
- Updated background.js to check for first run and missing settings
- Updated popup UI to show current settings and add settings button
- Settings are saved in chrome.storage.sync for persistence

The workflow works as follows:
1. On first install/update, extension checks if settings are configured
2. If settings are missing, automatically opens settings popup window
3. Users can access settings anytime through settings button in popup
4. Settings are saved persistently and used for initialization