### PR TITLE
Persist client ID in localStorage

### DIFF
--- a/pages/src/components/ClientSection.tsx
+++ b/pages/src/components/ClientSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { DB } from '../utils/db';
 import { API_URL } from '../utils/api';
 
@@ -10,6 +10,20 @@ export function ClientSection({ db }: ClientSectionProps) {
   const [clientId, setClientId] = useState('');
   const [data, setData] = useState('{}');
   const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    const savedClientId = localStorage.getItem('chroniclesync_client_id');
+    if (savedClientId) {
+      setClientId(savedClientId);
+      db.init(savedClientId).then(async () => {
+        const initialData = await db.getData();
+        setData(JSON.stringify(initialData, null, 2));
+        setIsInitialized(true);
+      }).catch(error => {
+        console.error('Error loading saved client:', error);
+      });
+    }
+  }, []);
 
   const initializeClient = async () => {
     if (!clientId) {

--- a/pages/src/utils/db.ts
+++ b/pages/src/utils/db.ts
@@ -8,6 +8,7 @@ export class DB {
 
   async init(clientId: string): Promise<void> {
     this._clientId = clientId;
+    localStorage.setItem('chroniclesync_client_id', clientId);
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(`sync_${clientId}`, 1);
 


### PR DESCRIPTION
This PR fixes the issue where client ID settings are lost between page reloads by:

- Storing the client ID in localStorage when initialized
- Loading the saved client ID when the component mounts
- Automatically initializing the client with the saved ID

These changes ensure that users do not need to re-enter their client ID every time they reload the page.