### PR TITLE
Add dedicated settings page to extension

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,6 +6,10 @@
   "action": {
     "default_popup": "popup.html"
   },
+  "options_ui": {
+    "page": "settings.html",
+    "open_in_tab": true
+  },
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -9,7 +9,7 @@
 <body>
   <div id="settings-container"></div>
   <script type="module">
-    import Settings from './settings.js';
+    import Settings from "./settings.js";
     const settings = new Settings();
     settings.init();
   </script>

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ChronicleSync Settings</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="settings.css">
+</head>
+<body>
+  <div id="settings-container"></div>
+  <script type="module">
+    import Settings from './settings.js';
+    const settings = new Settings();
+    settings.init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a dedicated settings page to the Chrome extension to fix the issue where users could not access the full settings interface.

### Changes
- Created `settings.html` file that provides a full settings page interface
- Updated `manifest.json` to include `options_ui` configuration
- Settings page now opens in a new tab for better usability and access to all settings

### How to Access Settings
1. Go to Chrome extensions page (chrome://extensions)
2. Find ChronicleSync Extension
3. Click the "Extensions options" button (gear icon)
4. Settings will open in a new tab with full functionality

This change allows users to properly access and modify all extension settings including API endpoint, Pages UI URL, and Client ID.