### PR TITLE
Fix TypeScript linting error in integration tests

### DIFF
--- a/extension/e2e/integration.spec.ts
+++ b/extension/e2e/integration.spec.ts
@@ -141,7 +141,7 @@ test.describe('ChronicleSync E2E Tests', () => {
       // Use the service worker to access history
       const history = await workers[0].evaluate(() => {
         return new Promise<chrome.history.HistoryItem[]>((resolve) => {
-          // @ts-ignore - chrome.history exists in extension context
+          // @ts-expect-error - chrome.history exists in extension context
           chrome.history.search({ text: '', maxResults: 10 }, (results) => {
             resolve(results);
           });


### PR DESCRIPTION
This PR fixes a linting error in the integration tests by replacing `@ts-ignore` with `@ts-expect-error` as recommended by ESLint.

Changes:
- Updated the TypeScript comment in `e2e/integration.spec.ts` to use `@ts-expect-error` instead of `@ts-ignore`
- All tests and linting checks now pass successfully