### PR TITLE
Add environment dropdown to settings

### DIFF
--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -28,6 +28,18 @@ describe('Settings', () => {
       input.id = id;
       form.appendChild(input);
     });
+
+    // Add environment dropdown
+    const envSelect = document.createElement('select');
+    envSelect.id = 'environment';
+    ['production', 'staging', 'custom'].forEach(value => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value;
+      envSelect.appendChild(option);
+    });
+    form.appendChild(envSelect);
+
     mockContainer.appendChild(form);
 
     // Add settings actions container with buttons
@@ -64,7 +76,8 @@ describe('Settings', () => {
     const mockConfig = {
       clientId: 'test-client',
       apiUrl: 'http://test-api.com',
-      pagesUrl: 'http://test-pages.com'
+      pagesUrl: 'http://test-pages.com',
+      environment: 'production'
     };
 
     chrome.storage.sync.get.mockImplementation((keys, callback) => {
@@ -77,13 +90,15 @@ describe('Settings', () => {
     expect(document.getElementById('clientId').value).toBe(mockConfig.clientId);
     expect(document.getElementById('apiUrl').value).toBe(mockConfig.apiUrl);
     expect(document.getElementById('pagesUrl').value).toBe(mockConfig.pagesUrl);
+    expect(document.getElementById('environment').value).toBe(mockConfig.environment);
   });
 
   it('handleSave updates config and shows success message', async () => {
     const newConfig = {
       clientId: 'new-client',
       apiUrl: 'http://new-api.com',
-      pagesUrl: 'http://new-pages.com'
+      pagesUrl: 'http://new-pages.com',
+      environment: 'custom'
     };
 
     settings.config = { ...settings.DEFAULT_SETTINGS };
@@ -93,6 +108,7 @@ describe('Settings', () => {
     document.getElementById('clientId').value = newConfig.clientId;
     document.getElementById('apiUrl').value = newConfig.apiUrl;
     document.getElementById('pagesUrl').value = newConfig.pagesUrl;
+    document.getElementById('environment').value = newConfig.environment;
 
     const mockEvent = {
       preventDefault: vi.fn()
@@ -112,7 +128,8 @@ describe('Settings', () => {
     settings.config = {
       clientId: 'custom-client',
       apiUrl: 'http://custom-api.com',
-      pagesUrl: 'http://custom-pages.com'
+      pagesUrl: 'http://custom-pages.com',
+      environment: 'custom'
     };
 
     await settings.handleReset();

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -52,10 +52,26 @@
         }
         
         input[type="text"]:focus,
-        input[type="url"]:focus {
+        input[type="url"]:focus,
+        select:focus {
             border-color: #4a90e2;
             outline: none;
             box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
+        }
+        
+        select.dropdown {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+            background-color: white;
+            cursor: pointer;
+        }
+        
+        #urlSettings.disabled {
+            opacity: 0.5;
+            pointer-events: none;
         }
         
         .settings-actions {
@@ -140,16 +156,26 @@
         
         <section class="settings-section">
             <div class="setting-item">
+                <label for="environment">Environment:</label>
+                <select id="environment" class="dropdown">
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div class="setting-item">
                 <label for="clientId">Client ID: <span class="required">*</span></label>
                 <input type="text" id="clientId" placeholder="Enter your client ID" required>
             </div>
-            <div class="setting-item">
-                <label for="apiUrl">API URL:</label>
-                <input type="url" id="apiUrl" placeholder="https://api.chroniclesync.xyz">
-            </div>
-            <div class="setting-item">
-                <label for="pagesUrl">Pages URL:</label>
-                <input type="url" id="pagesUrl" placeholder="https://pages.chroniclesync.xyz">
+            <div id="urlSettings">
+                <div class="setting-item">
+                    <label for="apiUrl">API URL:</label>
+                    <input type="url" id="apiUrl" placeholder="https://api.chroniclesync.xyz">
+                </div>
+                <div class="setting-item">
+                    <label for="pagesUrl">Pages URL:</label>
+                    <input type="url" id="pagesUrl" placeholder="https://pages.chroniclesync.xyz">
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
This PR adds a dropdown menu to the settings page that allows users to easily switch between different environments:

- Add dropdown to select between Production, Staging, and Custom environments
- Pre-define URLs for Production and Staging environments
- Make URL fields read-only for predefined environments
- Allow custom URL configuration when "Custom" is selected
- Update UI and handling for environment selection

This makes it easier for users to switch between environments without having to manually enter URLs each time.