### PR TITLE
Fix CORS credentials issue

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -56,6 +56,7 @@ export default {
       'Access-Control-Allow-Origin': finalOrigin,
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Credentials': 'true',
       'Access-Control-Max-Age': '86400',
     };
   },


### PR DESCRIPTION
This PR fixes the CORS issues by adding the `Access-Control-Allow-Credentials` header to the worker response headers.

### Changes
- Added `Access-Control-Allow-Credentials: true` header to CORS configuration
- Kept existing origin validation logic to ensure security

### Issue Fixed
Fixes the error: `Access to fetch at api.chroniclesync.xyz/api/history from origin chroniclesync.xyz has been blocked by CORS policy: The value of the Access-Control-Allow-Credentials header in the response is  which must be true when the requests credentials mode is include.`