### PR TITLE
Fix: Handle text response for client deletion

### DIFF
--- a/pages/src/components/AdminPanel.tsx
+++ b/pages/src/components/AdminPanel.tsx
@@ -41,8 +41,8 @@ export function AdminPanel() {
         throw new Error('Failed to delete client');
       }
 
-      await response.json();
-      alert('Client deleted successfully');
+      const text = await response.text();
+      alert(text || 'Client deleted successfully');
       refreshStats();
     } catch (error) {
       alert(`Error deleting client: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
This PR fixes an issue where the client deletion feature was failing because it tried to parse a text response as JSON.

**Changes:**
- Modified the delete client function to handle text response instead of JSON
- Shows the actual server response message or a default success message

**Issue:**
The server returns a plain text response "Client deleted" when deleting a client, but the frontend was trying to parse it as JSON, causing an error.

**Testing:**
1. Open the admin panel
2. Try to delete a client
3. Verify that the deletion succeeds and shows the success message