### PR TITLE
Fix staging API endpoint hostname pattern

### DIFF
--- a/pages/src/utils/api.ts
+++ b/pages/src/utils/api.ts
@@ -5,7 +5,7 @@ export const API_URL = (() => {
     return 'https://api.chroniclesync.xyz';
   }
   
-  if (hostname.endsWith('chroniclesync.pages.dev')) {
+  if (hostname.includes('chroniclesync-pages.pages.dev')) {
     return 'https://api-staging.chroniclesync.xyz';
   }
   


### PR DESCRIPTION
## Changes
- Updated the hostname pattern check to match any subdomain of chroniclesync-pages.pages.dev
- Changed from `endsWith()` to `includes()` to support the pattern `https://*.chroniclesync-pages.pages.dev/`

## Testing
This change will ensure that staging environments like:
- https://add-history-view.chroniclesync-pages.pages.dev/
- https://feature-x.chroniclesync-pages.pages.dev/

All correctly use the staging API endpoint (`https://api-staging.chroniclesync.xyz`).