### PR TITLE
fix: Update CORS configuration to support staging environment

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -32,6 +32,7 @@ export default {
   corsHeaders(origin = '*') {
     const allowedDomains = [
       'chroniclesync.xyz',
+      'api-staging.chroniclesync.xyz',
       'chroniclesync-pages.pages.dev',
       'localhost:8787',
       'localhost:8788',
@@ -45,6 +46,10 @@ export default {
       }
       if (domain === 'chroniclesync-pages.pages.dev') {
         return origin.endsWith('.chroniclesync-pages.pages.dev') || 
+          origin === `https://${domain}`;
+      }
+      if (domain === 'api-staging.chroniclesync.xyz') {
+        return origin.endsWith('.chroniclesync-pages.pages.dev') ||
           origin === `https://${domain}`;
       }
       return origin === `https://${domain}`;


### PR DESCRIPTION
This PR fixes the CORS issues in the staging environment by:

1. Adding `api-staging.chroniclesync.xyz` to the list of allowed domains
2. Updating the CORS configuration to properly handle requests from staging pages (including subdomains like `add-history-view.chroniclesync-pages.pages.dev`)

This should resolve the CORS errors when accessing the staging API from the staging pages.