### PR TITLE
feat: Completely disable CORS in staging environment

### DIFF
--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -4,9 +4,10 @@ import './test-setup.js';
 /**
  * @param {string} path
  * @param {RequestInit} [init]
+ * @param {string} [baseUrl]
  */
-async function makeRequest(path, init) {
-  const url = new URL(path, 'https://api.chroniclesync.xyz');
+async function makeRequest(path, init, baseUrl = 'https://api.chroniclesync.xyz') {
+  const url = new URL(path, baseUrl);
   return worker.fetch(new Request(url, init), getMiniflareBindings());
 }
 
@@ -626,6 +627,7 @@ describe('Worker API', () => {
     describe('Production Environment', () => {
       beforeEach(() => {
         // Mock production URL
+        // eslint-disable-next-line no-func-assign
         makeRequest = (path, init) => {
           const url = new URL(path, 'https://api.chroniclesync.xyz');
           return worker.fetch(new Request(url, init), getMiniflareBindings());
@@ -657,6 +659,7 @@ describe('Worker API', () => {
     describe('Staging Environment', () => {
       beforeEach(() => {
         // Mock staging URL
+        // eslint-disable-next-line no-func-assign
         makeRequest = (path, init) => {
           const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
           return worker.fetch(new Request(url, init), getMiniflareBindings());

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -690,41 +690,5 @@ describe('Worker API', () => {
         expect(resp.headers.get('Access-Control-Allow-Origin')).toBe('*');
       });
     });
-
-    describe('OPTIONS requests', () => {
-      it('handles OPTIONS request in production', async () => {
-        // eslint-disable-next-line no-func-assign
-        makeRequest = (path, init) => {
-          const url = new URL(path, 'https://api.chroniclesync.xyz');
-          return worker.fetch(new Request(url, init), getMiniflareBindings());
-        };
-
-        const resp = await makeRequest('/?clientId=test123', {
-          method: 'OPTIONS',
-          headers: { Origin: 'https://chroniclesync.xyz' }
-        });
-        expect(resp.status).toBe(200);
-        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
-        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
-        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
-      });
-
-      it('handles OPTIONS request in staging', async () => {
-        // eslint-disable-next-line no-func-assign
-        makeRequest = (path, init) => {
-          const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
-          return worker.fetch(new Request(url, init), getMiniflareBindings());
-        };
-
-        const resp = await makeRequest('/?clientId=test123', {
-          method: 'OPTIONS',
-          headers: { Origin: 'https://any-domain.com' }
-        });
-        expect(resp.status).toBe(200);
-        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('*');
-        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('*');
-        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
-      });
-    });
   });
 });

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -691,15 +691,40 @@ describe('Worker API', () => {
       });
     });
 
-    it('handles OPTIONS request', async () => {
-      const resp = await makeRequest('/?clientId=test123', {
-        method: 'OPTIONS',
-        headers: { Origin: 'https://chroniclesync.xyz' }
+    describe('OPTIONS requests', () => {
+      it('handles OPTIONS request in production', async () => {
+        // eslint-disable-next-line no-func-assign
+        makeRequest = (path, init) => {
+          const url = new URL(path, 'https://api.chroniclesync.xyz');
+          return worker.fetch(new Request(url, init), getMiniflareBindings());
+        };
+
+        const resp = await makeRequest('/?clientId=test123', {
+          method: 'OPTIONS',
+          headers: { Origin: 'https://chroniclesync.xyz' }
+        });
+        expect(resp.status).toBe(200);
+        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
+        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
+        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
       });
-      expect(resp.status).toBe(200);
-      expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
-      expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
-      expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
+
+      it('handles OPTIONS request in staging', async () => {
+        // eslint-disable-next-line no-func-assign
+        makeRequest = (path, init) => {
+          const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
+          return worker.fetch(new Request(url, init), getMiniflareBindings());
+        };
+
+        const resp = await makeRequest('/?clientId=test123', {
+          method: 'OPTIONS',
+          headers: { Origin: 'https://any-domain.com' }
+        });
+        expect(resp.status).toBe(200);
+        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('*');
+        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('*');
+        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
+      });
     });
   });
 });


### PR DESCRIPTION
This PR completely disables CORS restrictions in the staging environment while maintaining strict CORS rules in production.

Changes:
1. Added `isStaging` helper method to detect staging environment
2. When in staging, allow all origins (`Access-Control-Allow-Origin: *`)
3. Allow all methods and headers in staging
4. Maintain strict CORS rules in production
5. Store request object to access URL in CORS handler
6. Added comprehensive tests for both production and staging CORS behavior

This change makes the staging environment completely open for development and testing purposes, while keeping production secure with strict CORS rules.