### PR TITLE
fix: Suppress "Receiving end does not exist" error in background script

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -78,7 +78,18 @@ async function syncHistory() {
 
     lastSync = now;
     await chrome.storage.sync.set({ lastSync: now });
-    chrome.runtime.sendMessage({ type: 'syncComplete' });
+    
+    try {
+      // Notify any active extension views (popup, options page, etc.)
+      await chrome.runtime.sendMessage({ type: 'syncComplete' });
+    } catch (error) {
+      // Ignore errors when no listeners are available
+      if (!error.message.includes('Receiving end does not exist')) {
+        // eslint-disable-next-line no-console
+        console.error('Error sending sync complete message:', error);
+      }
+    }
+
     // eslint-disable-next-line no-console
     console.debug(`Successfully synced ${historyData.length} history items`);
   } catch (error) {

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -4,9 +4,10 @@ import './test-setup.js';
 /**
  * @param {string} path
  * @param {RequestInit} [init]
+ * @param {string} [baseUrl]
  */
-async function makeRequest(path, init) {
-  const url = new URL(path, 'https://api.chroniclesync.xyz');
+async function makeRequest(path, init, baseUrl = 'https://api.chroniclesync.xyz') {
+  const url = new URL(path, baseUrl);
   return worker.fetch(new Request(url, init), getMiniflareBindings());
 }
 
@@ -626,6 +627,7 @@ describe('Worker API', () => {
     describe('Production Environment', () => {
       beforeEach(() => {
         // Mock production URL
+        // eslint-disable-next-line no-func-assign
         makeRequest = (path, init) => {
           const url = new URL(path, 'https://api.chroniclesync.xyz');
           return worker.fetch(new Request(url, init), getMiniflareBindings());
@@ -657,6 +659,7 @@ describe('Worker API', () => {
     describe('Staging Environment', () => {
       beforeEach(() => {
         // Mock staging URL
+        // eslint-disable-next-line no-func-assign
         makeRequest = (path, init) => {
           const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
           return worker.fetch(new Request(url, init), getMiniflareBindings());

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -690,41 +690,5 @@ describe('Worker API', () => {
         expect(resp.headers.get('Access-Control-Allow-Origin')).toBe('*');
       });
     });
-
-    describe('OPTIONS requests', () => {
-      it('handles OPTIONS request in production', async () => {
-        // eslint-disable-next-line no-func-assign
-        makeRequest = (path, init) => {
-          const url = new URL(path, 'https://api.chroniclesync.xyz');
-          return worker.fetch(new Request(url, init), getMiniflareBindings());
-        };
-
-        const resp = await makeRequest('/?clientId=test123', {
-          method: 'OPTIONS',
-          headers: { Origin: 'https://chroniclesync.xyz' }
-        });
-        expect(resp.status).toBe(200);
-        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
-        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
-        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
-      });
-
-      it('handles OPTIONS request in staging', async () => {
-        // eslint-disable-next-line no-func-assign
-        makeRequest = (path, init) => {
-          const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
-          return worker.fetch(new Request(url, init), getMiniflareBindings());
-        };
-
-        const resp = await makeRequest('/?clientId=test123', {
-          method: 'OPTIONS',
-          headers: { Origin: 'https://any-domain.com' }
-        });
-        expect(resp.status).toBe(200);
-        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('*');
-        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('*');
-        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
-      });
-    });
   });
 });

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -691,15 +691,40 @@ describe('Worker API', () => {
       });
     });
 
-    it('handles OPTIONS request', async () => {
-      const resp = await makeRequest('/?clientId=test123', {
-        method: 'OPTIONS',
-        headers: { Origin: 'https://chroniclesync.xyz' }
+    describe('OPTIONS requests', () => {
+      it('handles OPTIONS request in production', async () => {
+        // eslint-disable-next-line no-func-assign
+        makeRequest = (path, init) => {
+          const url = new URL(path, 'https://api.chroniclesync.xyz');
+          return worker.fetch(new Request(url, init), getMiniflareBindings());
+        };
+
+        const resp = await makeRequest('/?clientId=test123', {
+          method: 'OPTIONS',
+          headers: { Origin: 'https://chroniclesync.xyz' }
+        });
+        expect(resp.status).toBe(200);
+        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
+        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
+        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
       });
-      expect(resp.status).toBe(200);
-      expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
-      expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
-      expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
+
+      it('handles OPTIONS request in staging', async () => {
+        // eslint-disable-next-line no-func-assign
+        makeRequest = (path, init) => {
+          const url = new URL(path, 'https://api-staging.chroniclesync.xyz');
+          return worker.fetch(new Request(url, init), getMiniflareBindings());
+        };
+
+        const resp = await makeRequest('/?clientId=test123', {
+          method: 'OPTIONS',
+          headers: { Origin: 'https://any-domain.com' }
+        });
+        expect(resp.status).toBe(200);
+        expect(resp.headers.get('Access-Control-Allow-Methods')).toBe('*');
+        expect(resp.headers.get('Access-Control-Allow-Headers')).toBe('*');
+        expect(resp.headers.get('Access-Control-Max-Age')).toBe('86400');
+      });
     });
   });
 });


### PR DESCRIPTION
This PR fixes the "Could not establish connection. Receiving end does not exist." error that appears in the console when the background script tries to send a sync completion message but no listeners are active.

Changes:
1. Wrap `chrome.runtime.sendMessage` in a try-catch block
2. Ignore the specific "Receiving end does not exist" error
3. Log other message-related errors for debugging

This is a normal error that occurs when the extension popup is closed (no active listeners), but it should be suppressed to avoid cluttering the console.