### PR TITLE
Add staging bucket cleanup script and workflow

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -1,0 +1,32 @@
+name: Cleanup Staging Bucket
+
+on:
+  workflow_dispatch:
+    inputs:
+      days_old:
+        description: 'Delete test clients older than X days'
+        required: true
+        default: '1'
+        type: string
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    environment: staging
+    
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Run Cleanup Script
+      env:
+        STAGING_BUCKET: ${{ secrets.STAGING_BUCKET }}
+      run: |
+        chmod +x ./scripts/cleanup_staging.sh
+        ./scripts/cleanup_staging.sh ${{ github.event.inputs.days_old }}

--- a/scripts/cleanup_staging.sh
+++ b/scripts/cleanup_staging.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Script to clean up test clients from staging bucket
+# Usage: ./cleanup_staging.sh [days_old]
+
+set -e
+
+# Default to cleaning up test clients older than 1 day if not specified
+DAYS_OLD=${1:-1}
+
+# AWS CLI command to list and delete test clients from staging bucket
+echo "Listing test clients older than ${DAYS_OLD} days in staging bucket..."
+
+# List objects with the test-client prefix and created before specified days
+aws s3api list-objects-v2 \
+    --bucket "${STAGING_BUCKET}" \
+    --prefix "test-client-" \
+    --query "Contents[?to_string(LastModified) < '`date -d "-${DAYS_OLD} days" --iso-8601=seconds`'].Key" \
+    --output text | \
+while read -r key; do
+    if [ ! -z "$key" ]; then
+        echo "Deleting: $key"
+        aws s3 rm "s3://${STAGING_BUCKET}/${key}"
+    fi
+done
+
+echo "Cleanup complete!"


### PR DESCRIPTION
This PR adds a script and GitHub Actions workflow to clean up old test clients from the staging bucket.

### Changes:
- Added `scripts/cleanup_staging.sh` to remove test clients older than X days from the staging bucket
- Added `cleanup-staging.yml` workflow to run the cleanup script via GitHub Actions

### Required Setup:
The following secrets need to be configured in the repository:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_REGION`
- `STAGING_BUCKET`

### Usage:
1. Go to Actions tab
2. Select "Cleanup Staging Bucket" workflow
3. Click "Run workflow"
4. Enter the number of days (default: 1)
5. Run the workflow