### PR TITLE
Allow setting clientId without initialization

### DIFF
--- a/pages/src/components/ClientSection.tsx
+++ b/pages/src/components/ClientSection.tsx
@@ -12,6 +12,12 @@ export function ClientSection({ db, onClientIdChange }: ClientSectionProps) {
   const [data, setData] = useState('{}');
   const [isInitialized, setIsInitialized] = useState(false);
 
+  const handleClientIdChange = (value: string) => {
+    setLocalClientId(value);
+    db.clientId = value;
+    onClientIdChange?.(value);
+  };
+
   const initializeClient = async () => {
     if (!localClientId) {
       alert('Please enter a client ID');
@@ -23,7 +29,6 @@ export function ClientSection({ db, onClientIdChange }: ClientSectionProps) {
       const initialData = await db.getData();
       setData(JSON.stringify(initialData, null, 2));
       setIsInitialized(true);
-      onClientIdChange?.(localClientId);
       await syncData();
     } catch (error) {
       alert(`Error initializing client: ${error instanceof Error ? error.message : String(error)}`);
@@ -70,7 +75,7 @@ export function ClientSection({ db, onClientIdChange }: ClientSectionProps) {
           type="text"
           id="clientId"
           value={localClientId}
-          onChange={(e) => setLocalClientId(e.target.value)}
+          onChange={(e) => handleClientIdChange(e.target.value)}
           placeholder="Enter client ID"
         />
         <button onClick={initializeClient}>Initialize</button>

--- a/pages/src/utils/db.ts
+++ b/pages/src/utils/db.ts
@@ -6,8 +6,12 @@ export class DB {
     return this._clientId;
   }
 
+  set clientId(value: string | null) {
+    this._clientId = value;
+  }
+
   async init(clientId: string): Promise<void> {
-    this._clientId = clientId;
+    this.clientId = clientId;
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(`sync_${clientId}`, 1);
 


### PR DESCRIPTION
This PR allows setting the client ID without requiring database initialization.

Changes:
- Added a `clientId` setter to the `DB` class
- Updated `ClientSection` component to set client ID immediately on input change
- Separated client ID setting from database initialization

This enables using the client ID before initializing the IndexedDB database.