### PR TITLE
Fix worker tests to handle pagination

### DIFF
--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -125,7 +125,15 @@ describe('Worker API', () => {
     expect(getResp.headers.get('Content-Type')).toBe('application/json');
     expect(getResp.headers.get('Last-Modified')).toBeTruthy();
     const getData = await getResp.json();
-    expect(getData).toEqual(testData);
+    expect(getData).toEqual({
+      ...testData,
+      pagination: {
+        total: 0,
+        page: 1,
+        pageSize: 10,
+        totalPages: 0
+      }
+    });
   });
 
   it('requires authentication for admin access', async () => {


### PR DESCRIPTION
This PR fixes the worker tests to handle the new pagination feature added in the `feature/history-filters-pagination` branch.

Changes:
- Updated the client data test to expect pagination information in the API response
- Added assertions for default pagination values (page=1, pageSize=10, total=0, totalPages=0)

All tests are now passing.