### PR TITLE
Add client-side encryption to history data

### DIFF
--- a/extension/src/encryption.js
+++ b/extension/src/encryption.js
@@ -38,10 +38,23 @@ async function importEncryptionKey(keyBase64) {
   );
 }
 
+function getCircularReplacer() {
+  const seen = new WeakSet();
+  return (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+}
+
 async function encrypt(data, keyBase64) {
   const key = await importEncryptionKey(keyBase64);
   const iv = crypto.getRandomValues(new Uint8Array(12));
-  const encodedData = new TextEncoder().encode(JSON.stringify(data));
+  const encodedData = new TextEncoder().encode(JSON.stringify(data, getCircularReplacer()));
   
   const encryptedData = await crypto.subtle.encrypt(
     {

--- a/extension/src/encryption.js
+++ b/extension/src/encryption.js
@@ -1,0 +1,78 @@
+// Encryption service using Web Crypto API
+async function generateEncryptionKey() {
+  const key = await window.crypto.subtle.generateKey(
+    {
+      name: 'AES-GCM',
+      length: 256
+    },
+    true,
+    ['encrypt', 'decrypt']
+  );
+  
+  // Export the key to store it
+  const exportedKey = await window.crypto.subtle.exportKey('raw', key);
+  const keyBase64 = btoa(String.fromCharCode(...new Uint8Array(exportedKey)));
+  return keyBase64;
+}
+
+async function importEncryptionKey(keyBase64) {
+  const keyBuffer = Uint8Array.from(atob(keyBase64), c => c.charCodeAt(0));
+  return window.crypto.subtle.importKey(
+    'raw',
+    keyBuffer,
+    'AES-GCM',
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+async function encrypt(data, keyBase64) {
+  const key = await importEncryptionKey(keyBase64);
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const encodedData = new TextEncoder().encode(JSON.stringify(data));
+  
+  const encryptedData = await window.crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv
+    },
+    key,
+    encodedData
+  );
+  
+  return {
+    encrypted: btoa(String.fromCharCode(...new Uint8Array(encryptedData))),
+    iv: btoa(String.fromCharCode(...iv))
+  };
+}
+
+async function decrypt(encryptedData, iv, keyBase64) {
+  const key = await importEncryptionKey(keyBase64);
+  const encryptedBuffer = Uint8Array.from(atob(encryptedData), c => c.charCodeAt(0));
+  const ivBuffer = Uint8Array.from(atob(iv), c => c.charCodeAt(0));
+  
+  const decryptedBuffer = await window.crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: ivBuffer
+    },
+    key,
+    encryptedBuffer
+  );
+  
+  const decryptedText = new TextDecoder().decode(decryptedBuffer);
+  return JSON.parse(decryptedText);
+}
+
+async function ensureEncryptionKey() {
+  const stored = await chrome.storage.local.get(['encryptionKey']);
+  if (stored.encryptionKey) {
+    return stored.encryptionKey;
+  }
+  
+  const newKey = await generateEncryptionKey();
+  await chrome.storage.local.set({ encryptionKey: newKey });
+  return newKey;
+}
+
+export { encrypt, decrypt, ensureEncryptionKey };


### PR DESCRIPTION
This PR adds client-side encryption to protect user history data before sending it to the server.

### Changes
- Add encryption service using Web Crypto API
- Implement AES-GCM 256-bit encryption for history data
- Add secure key generation and management
- Encrypt all data before sending to server
- Add version indicator for encrypted data format
- Fix circular reference issues in history data

### Technical Details
- Uses AES-GCM 256-bit encryption
- Unique IV (initialization vector) for each encryption
- Secure key generation using Web Crypto API
- Local storage of encryption keys
- Encrypted data format versioning
- Handles circular references in data structures
- Normalizes data types for consistent serialization

### Server-side Changes Required
The server API will need to be updated to handle the new encrypted data format. The server should expect:
- `encryptedData`: The encrypted history and device info
- `iv`: The initialization vector used for encryption
- `version`: The data format version (set to "2" for encrypted data)

### Security Benefits
1. All history data is encrypted before leaving the browser
2. Each user has their own unique encryption key
3. The encryption key never leaves the user's browser
4. The server only receives encrypted data and cannot read the actual history content
5. The encryption is transparent to the user while maintaining security

### Bug Fixes
1. Fixed service worker crypto API usage by removing window references
2. Fixed circular reference issues in history data
3. Added proper data type normalization
4. Improved error handling for data serialization