### PR TITLE
Fix settings tests by properly mocking crypto methods

### DIFF
--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -15,26 +15,27 @@ global.chrome = {
   }
 };
 
-// Mock crypto API
-global.crypto = {
-  getRandomValues: vi.fn((array) => {
-    for (let i = 0; i < array.length; i++) {
-      array[i] = Math.floor(Math.random() * 256);
-    }
-    return array;
-  }),
-  subtle: {
-    digest: vi.fn(async (algorithm, data) => {
-      // Simple mock that returns a fixed hash for testing
-      return new Uint8Array([
-        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
-        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-        0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
-      ]).buffer;
-    })
+// Mock crypto API methods
+const mockGetRandomValues = vi.fn((array) => {
+  for (let i = 0; i < array.length; i++) {
+    array[i] = Math.floor(Math.random() * 256);
   }
-};
+  return array;
+});
+
+const mockDigest = vi.fn(async (algorithm, data) => {
+  // Simple mock that returns a fixed hash for testing
+  return new Uint8Array([
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+  ]).buffer;
+});
+
+// Mock the methods on the crypto object
+vi.spyOn(crypto, 'getRandomValues').mockImplementation(mockGetRandomValues);
+vi.spyOn(crypto.subtle, 'digest').mockImplementation(mockDigest);
 
 // Import Settings after mocks
 import { Settings } from '../src/settings/Settings';

--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -23,7 +23,7 @@ const mockGetRandomValues = vi.fn((array) => {
   return array;
 });
 
-const mockDigest = vi.fn(async (algorithm, data) => {
+const mockDigest = vi.fn(async (_algorithm, _data) => {
   // Simple mock that returns a fixed hash for testing
   return new Uint8Array([
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,


### PR DESCRIPTION
This PR fixes the failing settings tests by properly mocking the crypto methods:

- Use vi.spyOn to mock crypto.getRandomValues and crypto.subtle.digest
- Keep original crypto object intact

All tests should now pass.