### PR TITLE
Remove hardcoded ports from pages and tests

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -93,6 +93,7 @@ jobs:
           API_URL: ${{ github.event.inputs.api_endpoint || (github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz') }}
           DEBUG: ${{ github.event.inputs.debug && 'pw:api' || '' }}
           PWDEBUG: ${{ github.event.inputs.debug && '1' || '' }}
+          PORT: 3000
         run: |
           npm ci
           npx playwright install --with-deps
@@ -159,6 +160,7 @@ jobs:
           API_URL: ${{ github.event.inputs.api_endpoint || (github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz') }}
           DEBUG: ${{ github.event.inputs.debug && 'pw:api' || '' }}
           PWDEBUG: ${{ github.event.inputs.debug && '1' || '' }}
+          PORT: 3000
         run: |
           npm ci
           npx playwright install --with-deps chromium

--- a/pages/config.ts
+++ b/pages/config.ts
@@ -9,7 +9,7 @@ export const paths = {
 };
 
 export const server = {
-  port: parseInt(process.env.PORT || '52691', 10),
-  webUrl: process.env.WEB_URL || `http://localhost:${process.env.PORT || '52691'}`,
+  port: parseInt(process.env.PORT || '3000', 10),
+  webUrl: process.env.WEB_URL || `http://localhost:${process.env.PORT || '3000'}`,
   apiUrl: process.env.API_URL || 'https://api-staging.chroniclesync.xyz'
 };

--- a/pages/e2e/history-view.spec.ts
+++ b/pages/e2e/history-view.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { server } from '../config';
 
 test('history view displays browser history', async ({ page }) => {
   // Mock the API response
@@ -32,7 +33,7 @@ test('history view displays browser history', async ({ page }) => {
   });
 
   // First visit home page to set client ID
-  await page.goto('http://localhost:52691/');
+  await page.goto(server.webUrl);
   await page.fill('#clientId', 'test-client-id');
   await page.click('text=Initialize');
   await page.screenshot({ path: 'test-results/history-view-home.png' });


### PR DESCRIPTION
This PR removes hardcoded port references and makes the development server port configurable:

- Replace hardcoded port 52691 with configurable port in config.ts
- Update history-view test to use server.webUrl from config
- Add PORT environment variable to GitHub Actions workflow
- Ensure all tests pass with dynamic port configuration

All tests have been verified to pass with the new configuration.