### PR TITLE
Remove hardcoded ports and use environment variables

### DIFF
--- a/pages/config.ts
+++ b/pages/config.ts
@@ -9,7 +9,7 @@ export const paths = {
 };
 
 export const server = {
-  port: parseInt(process.env.PORT || '3000', 10),
-  webUrl: process.env.WEB_URL || `http://localhost:${process.env.PORT || '3000'}`,
+  port: parseInt(process.env.PORT!, 10),
+  webUrl: process.env.WEB_URL!,
   apiUrl: process.env.API_URL || 'https://api-staging.chroniclesync.xyz'
 };

--- a/pages/package.json
+++ b/pages/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "jest",

--- a/pages/playwright.config.ts
+++ b/pages/playwright.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
   ],
   outputDir: 'test-results/',
   webServer: {
-    command: 'npm run dev',
-    port: Number(new URL(server.webUrl).port),
+    command: `PORT=${process.env.PORT} WEB_URL=${process.env.WEB_URL} npm run dev`,
+    port: Number(process.env.PORT),
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
This PR removes hardcoded ports from the configuration and uses environment variables instead. Changes include:

1. Updated config.ts to require PORT and WEB_URL environment variables
2. Updated playwright.config.ts to pass environment variables to the dev server
3. Updated package.json dev script to only specify host, not port

This makes the application more flexible by using whatever ports are provided by the runtime environment.