### PR TITLE
Add polyfills for crypto-browserify and process

### DIFF
--- a/pages/src/index.tsx
+++ b/pages/src/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';

--- a/pages/src/polyfills.ts
+++ b/pages/src/polyfills.ts
@@ -1,0 +1,12 @@
+import { Buffer } from 'buffer';
+
+// Add Buffer to window
+(window as any).Buffer = Buffer;
+
+// Add process to window
+(window as any).process = {
+  env: {},
+  browser: true,
+  version: '',
+  nextTick: (fn: Function, ...args: any[]) => setTimeout(() => fn(...args), 0)
+};

--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -4,10 +4,16 @@ import { paths, server } from './config';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'process.env': {},
+    'process.browser': true
+  },
   resolve: {
     alias: {
       crypto: 'crypto-browserify',
-      buffer: 'buffer'
+      buffer: 'buffer',
+      stream: 'stream-browserify',
+      process: 'process/browser'
     }
   },
   build: {


### PR DESCRIPTION
This PR adds the necessary polyfills for crypto-browserify and process to work in the browser environment. Changes include:

1. Added polyfills.ts to set up Buffer and process globals
2. Updated Vite config with proper aliases and defines
3. Added process and stream-browserify dependencies

This should fix the "process is not defined" error when loading the extension.