### PR TITLE
Add E2E tests for history sync functionality

### DIFF
--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('History Sync', () => {
+  test('should sync history between extension and server', async ({ page }) => {
+    // Navigate to the extension page
+    await page.goto('/');
+    await page.screenshot({ path: 'screenshots/initial-state.png' });
+
+    // Simulate adding history items
+    const mockHistoryItems = [
+      { url: 'https://example.com', title: 'Example Domain', visitTime: Date.now() },
+      { url: 'https://github.com', title: 'GitHub', visitTime: Date.now() - 1000 }
+    ];
+
+    // Add items to local storage to simulate extension
+    await page.evaluate((items) => {
+      localStorage.setItem('chroniclesync_history', JSON.stringify(items));
+    }, mockHistoryItems);
+
+    // Trigger sync
+    await page.click('button:has-text("Sync Now")');
+    await page.screenshot({ path: 'screenshots/after-sync.png' });
+
+    // Verify items are displayed in the UI
+    await expect(page.getByText('Example Domain')).toBeVisible();
+    await expect(page.getByText('GitHub')).toBeVisible();
+
+    // Clear local storage
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.screenshot({ path: 'screenshots/cleared-storage.png' });
+
+    // Trigger sync again to verify items are pulled from server
+    await page.click('button:has-text("Sync Now")');
+    await page.screenshot({ path: 'screenshots/after-second-sync.png' });
+
+    // Verify items are still displayed
+    await expect(page.getByText('Example Domain')).toBeVisible();
+    await expect(page.getByText('GitHub')).toBeVisible();
+  });
+
+  test('should handle offline mode', async ({ page }) => {
+    // Set the page to offline mode
+    await page.context().setOffline(true);
+    await page.goto('/');
+    await page.screenshot({ path: 'screenshots/offline-mode.png' });
+
+    // Add history items while offline
+    const offlineHistoryItem = {
+      url: 'https://offline-example.com',
+      title: 'Offline Example',
+      visitTime: Date.now()
+    };
+
+    await page.evaluate((item) => {
+      localStorage.setItem('chroniclesync_history', JSON.stringify([item]));
+    }, offlineHistoryItem);
+
+    // Verify offline item is visible
+    await expect(page.getByText('Offline Example')).toBeVisible();
+    await page.screenshot({ path: 'screenshots/offline-item-added.png' });
+
+    // Set the page back online
+    await page.context().setOffline(false);
+
+    // Trigger sync and verify the item is synced
+    await page.click('button:has-text("Sync Now")');
+    await page.screenshot({ path: 'screenshots/after-offline-sync.png' });
+
+    // Verify the offline item is still visible and synced
+    await expect(page.getByText('Offline Example')).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "chroniclesync",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.50.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: process.env.API_URL || 'https://api-staging.chroniclesync.xyz',
+    trace: 'on-first-retry',
+    screenshot: 'on',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    port: 51617,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
This PR adds end-to-end tests using Playwright to test the history sync functionality between the extension and server.

### Changes:
- Added Playwright configuration
- Created E2E test suite for history sync
- Added test cases for:
  - Basic sync functionality
  - Offline mode handling
  - Data persistence verification
- Configured screenshot capture for visual regression testing

### Testing:
To run the tests:
```bash
export API_URL='https://api-staging.chroniclesync.xyz'
xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npx playwright test --project=chromium
```

Screenshots will be saved in the `screenshots` directory.