### PR TITLE
Simplify e2e tests with frame buffer and staging server

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -164,9 +164,8 @@ jobs:
         run: |
           npm ci
           npx playwright install --with-deps chromium
-          # Extension tests always run in non-headless mode with Chromium
-          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
-            npx playwright test --project=chromium
+          # Run e2e tests with frame buffer
+          npm run test:e2e
 
       - name: Upload test results
         if: always()

--- a/extension/package.json
+++ b/extension/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' playwright test",
+    "test:e2e:debug": "PWDEBUG=1 xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' playwright test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/extension/playwright.config.ts
+++ b/extension/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     screenshot: 'on',
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
+    baseURL: process.env.API_URL || 'https://api-staging.chroniclesync.xyz',
     contextOptions: {
       logger: {
         isEnabled: () => true,


### PR DESCRIPTION
This PR simplifies the e2e test setup by:

- Adding npm scripts for running e2e tests with frame buffer (`test:e2e` and `test:e2e:debug`)
- Updating playwright config to use staging server URL by default
- Simplifying GitHub Actions workflow to use the new npm scripts

These changes make it easier to run e2e tests consistently across local development and CI environments while maintaining all required functionality.