### PR TITLE
Fix history view build configuration

### DIFF
--- a/extension/.eslintrc.json
+++ b/extension/.eslintrc.json
@@ -44,7 +44,8 @@
     }],
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "no-console": ["warn", { "allow": ["error", "warn", "info", "debug"] }]
   },
   "overrides": [
     {

--- a/extension/e2e/history-view.spec.ts
+++ b/extension/e2e/history-view.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect, getExtensionUrl } from './utils/extension';
-import { server } from './test-config';
 
 test.describe('History View', () => {
   test('history view should load and display entries', async ({ context, extensionId }) => {

--- a/extension/history.html
+++ b/extension/history.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="src/history.tsx"></script>
+    <script type="module" src="history.js"></script>
   </body>
 </html>

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import '../popup.css';
 
-import { HistoryEntry } from './types';
-
 export function App() {
   const [initialized, setInitialized] = useState(false);
   const [clientId, setClientId] = useState('');

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -14,6 +14,8 @@ const copyFiles = () => ({
     copyFileSync('settings.html', 'dist/settings.html');
     copyFileSync('settings.css', 'dist/settings.css');
     copyFileSync('bip39-wordlist.js', 'dist/bip39-wordlist.js');
+    copyFileSync('history.html', 'dist/history.html');
+    copyFileSync('history.css', 'dist/history.css');
   }
 });
 
@@ -26,7 +28,8 @@ export default defineConfig({
       input: {
         popup: resolve(__dirname, 'src/popup.tsx'),
         background: resolve(__dirname, 'background.js'),
-        settings: resolve(__dirname, 'src/settings/index.ts')
+        settings: resolve(__dirname, 'src/settings/index.ts'),
+        history: resolve(__dirname, 'src/history.tsx')
       },
       output: {
         format: 'es',


### PR DESCRIPTION
This PR fixes the history view build issues that were causing the ERR_FILE_NOT_FOUND error. Changes include:

- Add history.tsx to vite build inputs
- Copy history.html and history.css to dist directory
- Fix script path in history.html from src/history.tsx to history.js
- Update vite config to properly handle history view files

These changes ensure that all necessary files for the history view are properly included in the built extension package.