### PR TITLE
Fix history files missing from extension package

### DIFF
--- a/extension/scripts/build-extension.cjs
+++ b/extension/scripts/build-extension.cjs
@@ -15,10 +15,13 @@ const filesToCopy = [
   ['popup.css', 'popup.css'],
   ['settings.html', 'settings.html'],
   ['settings.css', 'settings.css'],
+  ['history.html', 'history.html'],
+  ['history.css', 'history.css'],
   ['bip39-wordlist.js', 'bip39-wordlist.js'],
   [join('dist', 'popup.js'), 'popup.js'],
   [join('dist', 'background.js'), 'background.js'],
   [join('dist', 'settings.js'), 'settings.js'],
+  [join('dist', 'history.js'), 'history.js'],
   [join('dist', 'assets'), 'assets']
 ];
 


### PR DESCRIPTION
This PR fixes the issue where history files were missing from the extension package.

Changes:
- Added history.html and history.css to the list of files to copy
- Added history.js to the list of built files to copy

These changes ensure that all history-related files are properly included in the final chrome-extension.zip package.