### PR TITLE
Fix history loading to use Chrome history API

### DIFF
--- a/extension/scripts/build-extension.cjs
+++ b/extension/scripts/build-extension.cjs
@@ -15,10 +15,13 @@ const filesToCopy = [
   ['popup.css', 'popup.css'],
   ['settings.html', 'settings.html'],
   ['settings.css', 'settings.css'],
+  ['history.html', 'history.html'],
+  ['history.css', 'history.css'],
   ['bip39-wordlist.js', 'bip39-wordlist.js'],
   [join('dist', 'popup.js'), 'popup.js'],
   [join('dist', 'background.js'), 'background.js'],
   [join('dist', 'settings.js'), 'settings.js'],
+  [join('dist', 'history.js'), 'history.js'],
   [join('dist', 'assets'), 'assets']
 ];
 

--- a/extension/src/history.tsx
+++ b/extension/src/history.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HistoryStore } from './db/HistoryStore';
 
 const ITEMS_PER_PAGE = 10;
 
@@ -28,10 +27,14 @@ const HistoryView: React.FC = () => {
   }, [searchTerm, history]);
 
   const loadHistory = async () => {
-    const historyStore = new HistoryStore();
-    await historyStore.init();
-    const items = await historyStore.getEntries();
-    setHistory(items.sort((a, b) => b.visitTime - a.visitTime));
+    // Send message to background script to get history
+    chrome.runtime.sendMessage({ type: 'getHistory', limit: 100 }, (response) => {
+      if (response && !response.error) {
+        setHistory(response.sort((a, b) => b.visitTime - a.visitTime));
+      } else {
+        console.error('Error loading history:', response?.error);
+      }
+    });
   };
 
   const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
This PR fixes the issue where no history entries were showing up in the history view.

Changes:
- Modified history.tsx to use Chrome history API instead of IndexedDB
- Removed unused HistoryStore import
- History entries are now fetched directly from Chrome history via background script

The history view should now properly display browsing history entries.