### PR TITLE
Fix e2e tests to use local test server

### DIFF
--- a/extension/e2e/history-view.spec.ts
+++ b/extension/e2e/history-view.spec.ts
@@ -1,6 +1,20 @@
 import { test, expect, getExtensionUrl } from './utils/extension';
+import { createTestServer } from './test-server';
+
+const TEST_PORT = 51016;
 
 test.describe('History View', () => {
+  let cleanup: () => void;
+
+  test.beforeAll(async () => {
+    cleanup = await createTestServer(TEST_PORT);
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      cleanup();
+    }
+  });
   test('history view should load and display entries', async ({ context, extensionId }) => {
     // First, set up a client ID through the settings page
     const settingsPage = await context.newPage();
@@ -33,9 +47,9 @@ test.describe('History View', () => {
 
     // Create some test history entries
     const testPages = [
-      'https://example.com',
-      'https://test.com',
-      'https://demo.com'
+      `http://localhost:${TEST_PORT}/page1`,
+      `http://localhost:${TEST_PORT}/page2`,
+      `http://localhost:${TEST_PORT}/page3`
     ];
 
     // Visit test pages to create history entries

--- a/extension/e2e/test-server.ts
+++ b/extension/e2e/test-server.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import cors from 'cors';
+
+export function createTestServer(port: number) {
+  const app = express();
+  app.use(cors());
+
+  // Test pages
+  app.get('/page1', (_, res) => {
+    res.send('<html><head><title>Test Page 1</title></head><body><h1>Test Page 1</h1></body></html>');
+  });
+
+  app.get('/page2', (_, res) => {
+    res.send('<html><head><title>Test Page 2</title></head><body><h1>Test Page 2</h1></body></html>');
+  });
+
+  app.get('/page3', (_, res) => {
+    res.send('<html><head><title>Test Page 3</title></head><body><h1>Test Page 3</h1></body></html>');
+  });
+
+  return new Promise<() => void>((resolve) => {
+    const server = app.listen(port, () => {
+      console.log(`Test server running at http://localhost:${port}`);
+      resolve(() => {
+        server.close();
+      });
+    });
+  });
+}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -15,6 +15,8 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/chrome": "^0.0.297",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.12.0",
         "@types/react": "^19.0.8",
@@ -3786,6 +3788,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.297",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.297.tgz",
@@ -3797,12 +3810,58 @@
         "@types/har-format": "*"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/filesystem": {
       "version": "0.0.36",
@@ -3835,6 +3894,13 @@
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
       "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3888,6 +3954,13 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
@@ -3897,6 +3970,20 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.0.8",
@@ -3916,6 +4003,29 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -24,6 +24,8 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/chrome": "^0.0.297",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.12.0",
     "@types/react": "^19.0.8",


### PR DESCRIPTION
This PR fixes the e2e test failures in CI by using a local test server instead of real domains.

Changes:
- Add test-server.ts to serve test pages locally
- Update history-view.spec.ts to use local test pages instead of real domains
- Fix TypeScript issues with test server setup
- Add @types/cors and @types/express dependencies

The test failures were happening because the CI environment was having SSL certificate issues with real domains. By using a local test server, we avoid these issues while still properly testing the functionality.