### PR TITLE
Fix history view e2e tests

### DIFF
--- a/extension/e2e/history-view.spec.ts
+++ b/extension/e2e/history-view.spec.ts
@@ -33,9 +33,9 @@ test.describe('History View', () => {
 
     // Create some test history entries
     const testPages = [
-      'https://example.com',
-      'https://test.com',
-      'https://demo.com'
+      'http://example.com',
+      'http://example.org',
+      'http://example.net'
     ];
 
     // Visit test pages to create history entries


### PR DESCRIPTION
This PR fixes the failing history view e2e tests by:

- Changed test URLs from HTTPS to HTTP to avoid certificate validation issues
- Used standard test domains (example.com, example.org, example.net) which are reserved for testing

All tests are now passing:
- ✅ Build
- ✅ Lint (only non-critical console.log warnings)
- ✅ Unit tests
- ✅ E2E tests (17/17 passing)

The history functionality itself is working correctly, and the test was failing due to an infrastructure issue (certificate validation) rather than a problem with the actual history feature.