### PR TITLE
Add IndexedDB mock for tests

### DIFF
--- a/extension/__tests__/encryption.test.ts
+++ b/extension/__tests__/encryption.test.ts
@@ -5,7 +5,7 @@ describe('EncryptionService', () => {
   let encryptionService: EncryptionService;
 
   beforeEach(async () => {
-    encryptionService = new EncryptionService(testMnemonic);
+    encryptionService = await EncryptionService.create(testMnemonic);
   });
 
   it('should encrypt and decrypt data correctly', async () => {

--- a/extension/__tests__/encryption.test.ts
+++ b/extension/__tests__/encryption.test.ts
@@ -1,0 +1,74 @@
+import { EncryptionService } from '../src/services/EncryptionService';
+
+describe('EncryptionService', () => {
+  const testMnemonic = 'test test test test test test test test test test test junk';
+  let encryptionService: EncryptionService;
+
+  beforeEach(async () => {
+    encryptionService = new EncryptionService(testMnemonic);
+  });
+
+  it('should encrypt and decrypt data correctly', async () => {
+    const testData = 'Hello, World!';
+    const encrypted = await encryptionService.encrypt(testData);
+
+    expect(encrypted.ciphertext).toBeTruthy();
+    expect(encrypted.iv).toBeTruthy();
+    expect(typeof encrypted.ciphertext).toBe('string');
+    expect(typeof encrypted.iv).toBe('string');
+
+    const decrypted = await encryptionService.decrypt(encrypted.ciphertext, encrypted.iv);
+    expect(decrypted).toBe(testData);
+  });
+
+  it('should generate unique IVs for each encryption', async () => {
+    const testData = 'Test data';
+    const encrypted1 = await encryptionService.encrypt(testData);
+    const encrypted2 = await encryptionService.encrypt(testData);
+
+    expect(encrypted1.iv).not.toBe(encrypted2.iv);
+    expect(encrypted1.ciphertext).not.toBe(encrypted2.ciphertext);
+  });
+
+  it('should handle empty strings', async () => {
+    const testData = '';
+    const encrypted = await encryptionService.encrypt(testData);
+    const decrypted = await encryptionService.decrypt(encrypted.ciphertext, encrypted.iv);
+
+    expect(decrypted).toBe(testData);
+  });
+
+  it('should handle special characters', async () => {
+    const testData = '!@#$%^&*()_+-=[]{}|;:,.<>?`~';
+    const encrypted = await encryptionService.encrypt(testData);
+    const decrypted = await encryptionService.decrypt(encrypted.ciphertext, encrypted.iv);
+
+    expect(decrypted).toBe(testData);
+  });
+
+  it('should handle long strings', async () => {
+    const testData = 'a'.repeat(10000);
+    const encrypted = await encryptionService.encrypt(testData);
+    const decrypted = await encryptionService.decrypt(encrypted.ciphertext, encrypted.iv);
+
+    expect(decrypted).toBe(testData);
+  });
+
+  it('should fail with invalid IV', async () => {
+    const testData = 'Test data';
+    const encrypted = await encryptionService.encrypt(testData);
+
+    await expect(
+      encryptionService.decrypt(encrypted.ciphertext, 'invalid_iv')
+    ).rejects.toThrow();
+  });
+
+  it('should fail with invalid ciphertext', async () => {
+    const testData = 'Test data';
+    const encrypted = await encryptionService.encrypt(testData);
+
+    await expect(
+      encryptionService.decrypt('invalid_ciphertext', encrypted.iv)
+    ).rejects.toThrow();
+  });
+});

--- a/extension/__tests__/history-store.test.ts
+++ b/extension/__tests__/history-store.test.ts
@@ -1,0 +1,116 @@
+import { HistoryStore } from '../src/db/HistoryStore';
+import { EncryptionService } from '../src/services/EncryptionService';
+import { HistoryEntry } from '../src/types';
+
+describe('HistoryStore', () => {
+  let historyStore: HistoryStore;
+  let encryptionService: EncryptionService;
+
+  const testMnemonic = 'test test test test test test test test test test test junk';
+  const testEntry: Omit<HistoryEntry, 'syncStatus'> = {
+    visitId: '123',
+    url: 'https://example.com',
+    title: 'Example Website',
+    visitTime: Date.now(),
+    lastVisitTime: Date.now()
+  };
+
+  beforeEach(async () => {
+    // Clear IndexedDB before each test
+    const databases = await window.indexedDB.databases();
+    await Promise.all(
+      databases.map(db => window.indexedDB.deleteDatabase(db.name!))
+    );
+
+    historyStore = new HistoryStore();
+    await historyStore.init();
+
+    encryptionService = new EncryptionService(testMnemonic);
+  });
+
+  it('should store unencrypted entries when encryption service is not set', async () => {
+    await historyStore.addEntry(testEntry);
+    const entries = await historyStore.getEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].url).toBe(testEntry.url);
+    expect(entries[0].title).toBe(testEntry.title);
+    expect(entries[0].encrypted).toBe(false);
+  });
+
+  it('should store and retrieve encrypted entries', async () => {
+    historyStore.setEncryptionService(encryptionService);
+    await historyStore.addEntry(testEntry);
+    const entries = await historyStore.getEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].url).toBe(testEntry.url);
+    expect(entries[0].title).toBe(testEntry.title);
+    expect(entries[0].encrypted).toBe(true);
+    expect(entries[0].encryptedData).toBeTruthy();
+    expect(entries[0].encryptedData!.url.ciphertext).toBeTruthy();
+    expect(entries[0].encryptedData!.url.iv).toBeTruthy();
+  });
+
+  it('should handle multiple entries with encryption', async () => {
+    historyStore.setEncryptionService(encryptionService);
+
+    const entries = [
+      { ...testEntry, visitId: '1', url: 'https://example1.com', title: 'Example 1' },
+      { ...testEntry, visitId: '2', url: 'https://example2.com', title: 'Example 2' },
+      { ...testEntry, visitId: '3', url: 'https://example3.com', title: 'Example 3' }
+    ];
+
+    await Promise.all(entries.map(entry => historyStore.addEntry(entry)));
+    const storedEntries = await historyStore.getEntries();
+
+    expect(storedEntries).toHaveLength(3);
+    storedEntries.forEach((entry, i) => {
+      expect(entry.url).toBe(entries[i].url);
+      expect(entry.title).toBe(entries[i].title);
+      expect(entry.encrypted).toBe(true);
+      expect(entry.encryptedData).toBeTruthy();
+    });
+  });
+
+  it('should handle unsynced entries with encryption', async () => {
+    historyStore.setEncryptionService(encryptionService);
+    await historyStore.addEntry(testEntry);
+
+    const unsyncedEntries = await historyStore.getUnsyncedEntries();
+    expect(unsyncedEntries).toHaveLength(1);
+    expect(unsyncedEntries[0].url).toBe(testEntry.url);
+    expect(unsyncedEntries[0].title).toBe(testEntry.title);
+    expect(unsyncedEntries[0].syncStatus).toBe('pending');
+    expect(unsyncedEntries[0].encrypted).toBe(true);
+  });
+
+  it('should mark entries as synced', async () => {
+    historyStore.setEncryptionService(encryptionService);
+    await historyStore.addEntry(testEntry);
+
+    let unsyncedEntries = await historyStore.getUnsyncedEntries();
+    expect(unsyncedEntries).toHaveLength(1);
+
+    await historyStore.markAsSynced(testEntry.visitId);
+
+    unsyncedEntries = await historyStore.getUnsyncedEntries();
+    expect(unsyncedEntries).toHaveLength(0);
+  });
+
+  it('should handle switching encryption on and off', async () => {
+    // Add unencrypted entry
+    await historyStore.addEntry(testEntry);
+    let entries = await historyStore.getEntries();
+    expect(entries[0].encrypted).toBe(false);
+
+    // Enable encryption and add another entry
+    historyStore.setEncryptionService(encryptionService);
+    await historyStore.addEntry({ ...testEntry, visitId: '456' });
+    entries = await historyStore.getEntries();
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].encrypted).toBe(false);
+    expect(entries[1].encrypted).toBe(true);
+  });
+});

--- a/extension/__tests__/history-store.test.ts
+++ b/extension/__tests__/history-store.test.ts
@@ -16,16 +16,14 @@ describe('HistoryStore', () => {
   };
 
   beforeEach(async () => {
-    // Clear IndexedDB before each test
-    const databases = await window.indexedDB.databases();
-    await Promise.all(
-      databases.map(db => window.indexedDB.deleteDatabase(db.name!))
-    );
+    // Set up mock IndexedDB
+    const { setupIndexedDBMock } = await import('./mocks/indexedDB');
+    setupIndexedDBMock();
 
     historyStore = new HistoryStore();
     await historyStore.init();
 
-    encryptionService = new EncryptionService(testMnemonic);
+    encryptionService = await EncryptionService.create(testMnemonic);
   });
 
   it('should store unencrypted entries when encryption service is not set', async () => {

--- a/extension/__tests__/history-sync.test.ts
+++ b/extension/__tests__/history-sync.test.ts
@@ -1,0 +1,151 @@
+import { HistorySync } from '../src/services/HistorySync';
+import { Settings } from '../src/settings/Settings';
+import { EncryptionService } from '../src/services/EncryptionService';
+import { HistoryEntry } from '../src/types';
+
+describe('HistorySync', () => {
+  let historySync: HistorySync;
+  let settings: Settings;
+  let encryptionService: EncryptionService;
+  const testMnemonic = 'test test test test test test test test test test test junk';
+
+  beforeEach(async () => {
+    // Clear IndexedDB before each test
+    const databases = await window.indexedDB.databases();
+    await Promise.all(
+      databases.map(db => window.indexedDB.deleteDatabase(db.name!))
+    );
+
+    // Mock chrome.history API
+    global.chrome = {
+      history: {
+        search: jest.fn(),
+        getVisits: jest.fn(),
+        onVisited: {
+          addListener: jest.fn()
+        }
+      },
+      storage: {
+        sync: {
+          get: jest.fn().mockResolvedValue({ clientId: 'test-client' })
+        }
+      }
+    } as any;
+
+    settings = new Settings();
+    encryptionService = new EncryptionService(testMnemonic);
+    historySync = new HistorySync(settings, encryptionService);
+    await historySync.init();
+  });
+
+  it('should initialize with encryption service', async () => {
+    const testEntry: HistoryEntry = {
+      visitId: '123',
+      url: 'https://example.com',
+      title: 'Example Website',
+      visitTime: Date.now(),
+      lastVisitTime: Date.now(),
+      platform: 'test',
+      browserName: 'test',
+      syncStatus: 'pending'
+    };
+
+    // Mock chrome.history.search response
+    (chrome.history.search as jest.Mock).mockResolvedValue([{
+      url: testEntry.url,
+      title: testEntry.title,
+      lastVisitTime: testEntry.lastVisitTime
+    }]);
+
+    // Mock chrome.history.getVisits response
+    (chrome.history.getVisits as jest.Mock).mockResolvedValue([{
+      visitId: testEntry.visitId,
+      visitTime: testEntry.visitTime
+    }]);
+
+    // Trigger initial history load
+    await historySync.init();
+
+    // Get stored entries
+    const entries = await historySync.getHistory();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].encrypted).toBe(true);
+    expect(entries[0].encryptedData).toBeTruthy();
+    expect(entries[0].url).toBe(testEntry.url);
+    expect(entries[0].title).toBe(testEntry.title);
+  });
+
+  it('should sync encrypted entries', async () => {
+    const testEntry: HistoryEntry = {
+      visitId: '123',
+      url: 'https://example.com',
+      title: 'Example Website',
+      visitTime: Date.now(),
+      lastVisitTime: Date.now(),
+      platform: 'test',
+      browserName: 'test',
+      syncStatus: 'pending'
+    };
+
+    // Add entry to history
+    await historySync.getHistory();
+
+    // Mock sync response
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true })
+    });
+
+    // Start sync
+    await historySync.startSync();
+
+    // Verify sync request
+    expect(fetch).toHaveBeenCalled();
+    const [url, options] = (fetch as jest.Mock).mock.calls[0];
+    const payload = JSON.parse(options.body);
+    
+    expect(payload.encrypted).toBe(true);
+    expect(payload.history[0].url.ciphertext).toBeTruthy();
+    expect(payload.history[0].url.iv).toBeTruthy();
+    expect(payload.history[0].title.ciphertext).toBeTruthy();
+    expect(payload.history[0].title.iv).toBeTruthy();
+  });
+
+  it('should handle encryption errors gracefully', async () => {
+    // Create invalid encryption service
+    const invalidEncryptionService = {
+      encrypt: jest.fn().mockRejectedValue(new Error('Encryption failed')),
+      decrypt: jest.fn().mockRejectedValue(new Error('Decryption failed'))
+    };
+
+    historySync = new HistorySync(settings, invalidEncryptionService as any);
+    await historySync.init();
+
+    const testEntry: HistoryEntry = {
+      visitId: '123',
+      url: 'https://example.com',
+      title: 'Example Website',
+      visitTime: Date.now(),
+      lastVisitTime: Date.now(),
+      platform: 'test',
+      browserName: 'test',
+      syncStatus: 'pending'
+    };
+
+    // Mock chrome.history.search response
+    (chrome.history.search as jest.Mock).mockResolvedValue([{
+      url: testEntry.url,
+      title: testEntry.title,
+      lastVisitTime: testEntry.lastVisitTime
+    }]);
+
+    // Mock chrome.history.getVisits response
+    (chrome.history.getVisits as jest.Mock).mockResolvedValue([{
+      visitId: testEntry.visitId,
+      visitTime: testEntry.visitTime
+    }]);
+
+    // Expect sync to fail gracefully
+    await expect(historySync.startSync()).rejects.toThrow();
+  });
+});

--- a/extension/__tests__/mocks/indexedDB.ts
+++ b/extension/__tests__/mocks/indexedDB.ts
@@ -1,0 +1,183 @@
+class MockIDBRequest {
+  result: any = null;
+  error: Error | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onsuccess: ((event: Event) => void) | null = null;
+
+  _triggerSuccess() {
+    if (this.onsuccess) {
+      this.onsuccess(new Event('success'));
+    }
+  }
+
+  _triggerError(error: Error) {
+    this.error = error;
+    if (this.onerror) {
+      this.onerror(new Event('error'));
+    }
+  }
+}
+
+class MockIDBIndex {
+  constructor(private store: MockIDBObjectStore, private keyPath: string) {}
+
+  getAll(query?: any): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        const allData = Array.from(this.store.data.values());
+        if (query !== undefined && query !== null) {
+          request.result = allData.filter(item => item[this.keyPath] === query);
+        } else {
+          request.result = allData.sort((a, b) => {
+            const aValue = a[this.keyPath];
+            const bValue = b[this.keyPath];
+            if (typeof aValue === 'number' && typeof bValue === 'number') {
+              return bValue - aValue; // Sort in descending order for numbers
+            }
+            return String(aValue).localeCompare(String(bValue));
+          });
+        }
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+}
+
+class MockIDBObjectStore {
+  data: Map<string, any> = new Map();
+  private indexes: Map<string, MockIDBIndex> = new Map();
+
+  put(value: any, key?: string): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        const actualKey = key || value.visitId;
+        this.data.set(actualKey, value);
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+
+  get(key: string): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        request.result = this.data.get(key);
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+
+  getAll(): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        request.result = Array.from(this.data.values());
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+
+  createIndex(name: string, keyPath: string): MockIDBIndex {
+    const index = new MockIDBIndex(this, keyPath);
+    this.indexes.set(name, index);
+    return index;
+  }
+
+  index(name: string): MockIDBIndex {
+    const index = this.indexes.get(name);
+    if (!index) {
+      throw new Error(`Index ${name} not found`);
+    }
+    return index;
+  }
+}
+
+class MockIDBTransaction {
+  private store: MockIDBObjectStore;
+
+  constructor(store: MockIDBObjectStore) {
+    this.store = store;
+  }
+
+  objectStore(): MockIDBObjectStore {
+    return this.store;
+  }
+}
+
+class MockIDBDatabase {
+  private store: MockIDBObjectStore = new MockIDBObjectStore();
+  objectStoreNames = {
+    contains: () => true
+  };
+
+  createObjectStore(name: string, options: any): MockIDBObjectStore {
+    // Create indexes that are used in the app
+    const store = this.store;
+    store.createIndex('visitTime', 'visitTime');
+    store.createIndex('syncStatus', 'syncStatus');
+    store.createIndex('url', 'url');
+    return store;
+  }
+
+  transaction(): MockIDBTransaction {
+    return new MockIDBTransaction(this.store);
+  }
+}
+
+export class MockIndexedDB {
+  private databases: Map<string, MockIDBDatabase> = new Map();
+
+  open(name: string): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        let db = this.databases.get(name);
+        if (!db) {
+          db = new MockIDBDatabase();
+          this.databases.set(name, db);
+        }
+        request.result = db;
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+
+  deleteDatabase(name: string): MockIDBRequest {
+    const request = new MockIDBRequest();
+    setTimeout(() => {
+      try {
+        this.databases.delete(name);
+        request._triggerSuccess();
+      } catch (error) {
+        request._triggerError(error as Error);
+      }
+    }, 0);
+    return request;
+  }
+}
+
+export function setupIndexedDBMock() {
+  const mockIndexedDB = new MockIndexedDB();
+  Object.defineProperty(window, 'indexedDB', {
+    value: mockIndexedDB,
+    writable: true
+  });
+  return mockIndexedDB;
+}

--- a/extension/src/services/EncryptionService.ts
+++ b/extension/src/services/EncryptionService.ts
@@ -1,0 +1,64 @@
+import { Buffer } from 'buffer';
+import { pbkdf2Sync, randomBytes } from 'crypto';
+
+export class EncryptionService {
+  private readonly key: CryptoKey;
+  private static readonly SALT = 'chroniclesync_v1';
+  private static readonly KEY_LENGTH = 32; // 256 bits
+  private static readonly ITERATIONS = 100000;
+
+  constructor(mnemonic: string) {
+    // Derive encryption key from mnemonic using PBKDF2
+    const derivedKey = pbkdf2Sync(
+      mnemonic,
+      EncryptionService.SALT,
+      EncryptionService.ITERATIONS,
+      EncryptionService.KEY_LENGTH,
+      'sha256'
+    );
+
+    // Import the key for use with Web Crypto API
+    this.key = await crypto.subtle.importKey(
+      'raw',
+      derivedKey,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  async encrypt(data: string): Promise<{ ciphertext: string; iv: string }> {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encodedData = new TextEncoder().encode(data);
+
+    const encryptedData = await crypto.subtle.encrypt(
+      {
+        name: 'AES-GCM',
+        iv
+      },
+      this.key,
+      encodedData
+    );
+
+    return {
+      ciphertext: Buffer.from(encryptedData).toString('base64'),
+      iv: Buffer.from(iv).toString('base64')
+    };
+  }
+
+  async decrypt(ciphertext: string, iv: string): Promise<string> {
+    const encryptedData = Buffer.from(ciphertext, 'base64');
+    const ivBuffer = Buffer.from(iv, 'base64');
+
+    const decryptedData = await crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: ivBuffer
+      },
+      this.key,
+      encryptedData
+    );
+
+    return new TextDecoder().decode(decryptedData);
+  }
+}

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -1,5 +1,20 @@
 import { HistoryVisit } from '../services/SyncService';
 
+export interface EncryptedData {
+  ciphertext: string;
+  iv: string;
+}
+
+export interface EncryptedHistoryVisit {
+  id: string;
+  url: EncryptedData;
+  title: EncryptedData;
+  visitTime: number;
+  lastVisitTime: number;
+}
+
 export interface HistoryEntry extends HistoryVisit {
   syncStatus: 'pending' | 'synced' | 'error';
+  encrypted?: boolean;
+  encryptedData?: EncryptedHistoryVisit;
 }


### PR DESCRIPTION
This PR adds a mock implementation of IndexedDB for testing. The mock supports:

- Basic operations (put, get, getAll)
- Indexes with sorting and filtering
- Async operations with setTimeout

There are still some failing tests that need to be fixed, but this is a good starting point for improving our test infrastructure.