### PR TITLE
Add device and OS filtering to history view

### DIFF
--- a/extension/history.css
+++ b/extension/history.css
@@ -11,12 +11,31 @@
   margin-bottom: 16px;
 }
 
+.history-filters {
+  margin-bottom: 16px;
+}
+
 .history-search {
   width: 100%;
   padding: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.filter-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.platform-filter,
+.browser-filter {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
 }
 
 .history-list {

--- a/extension/src/history.tsx
+++ b/extension/src/history.tsx
@@ -6,26 +6,53 @@ const ITEMS_PER_PAGE = 10;
 
 import { HistoryEntry } from './types';
 
+interface FilterOptions {
+  platform: string;
+  browserName: string;
+}
+
 const HistoryView: React.FC = () => {
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [filteredHistory, setFilteredHistory] = useState<HistoryEntry[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+  const [filters, setFilters] = useState<FilterOptions>({ platform: '', browserName: '' });
+  const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
+  const [availableBrowsers, setAvailableBrowsers] = useState<string[]>([]);
 
   useEffect(() => {
     loadHistory();
   }, []);
 
   useEffect(() => {
-    const filtered = history.filter(item => 
-      item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      item.url.toLowerCase().includes(searchTerm.toLowerCase())
-    );
+    if (history.length > 0) {
+      const platforms = [...new Set(history.map(item => item.platform))];
+      const browsers = [...new Set(history.map(item => item.browserName))];
+      setAvailablePlatforms(platforms);
+      setAvailableBrowsers(browsers);
+    }
+  }, [history]);
+
+  useEffect(() => {
+    const filtered = history.filter(item => {
+      const matchesSearch = searchTerm === '' || 
+        item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        item.url.toLowerCase().includes(searchTerm.toLowerCase());
+      
+      const matchesPlatform = filters.platform === '' || 
+        item.platform === filters.platform;
+      
+      const matchesBrowser = filters.browserName === '' || 
+        item.browserName === filters.browserName;
+
+      return matchesSearch && matchesPlatform && matchesBrowser;
+    });
+    
     setFilteredHistory(filtered);
     setTotalPages(Math.ceil(filtered.length / ITEMS_PER_PAGE));
     setCurrentPage(1);
-  }, [searchTerm, history]);
+  }, [searchTerm, filters, history]);
 
   const loadHistory = async () => {
     const historyStore = new HistoryStore();
@@ -36,6 +63,10 @@ const HistoryView: React.FC = () => {
 
   const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(event.target.value);
+  };
+
+  const handleFilterChange = (type: keyof FilterOptions, value: string) => {
+    setFilters(prev => ({ ...prev, [type]: value }));
   };
 
   const getCurrentPageItems = () => {
@@ -56,13 +87,37 @@ const HistoryView: React.FC = () => {
       <div className="history-header">
         <h2>Browsing History</h2>
       </div>
-      <input
-        type="text"
-        className="history-search"
-        placeholder="Search history..."
-        value={searchTerm}
-        onChange={handleSearch}
-      />
+      <div className="history-filters">
+        <input
+          type="text"
+          className="history-search"
+          placeholder="Search history..."
+          value={searchTerm}
+          onChange={handleSearch}
+        />
+        <div className="filter-controls">
+          <select
+            value={filters.platform}
+            onChange={(e) => handleFilterChange('platform', e.target.value)}
+            className="platform-filter"
+          >
+            <option value="">All Platforms</option>
+            {availablePlatforms.map(platform => (
+              <option key={platform} value={platform}>{platform}</option>
+            ))}
+          </select>
+          <select
+            value={filters.browserName}
+            onChange={(e) => handleFilterChange('browserName', e.target.value)}
+            className="browser-filter"
+          >
+            <option value="">All Browsers</option>
+            {availableBrowsers.map(browser => (
+              <option key={browser} value={browser}>{browser}</option>
+            ))}
+          </select>
+        </div>
+      </div>
       <div className="history-list">
         {getCurrentPageItems().map(item => (
           <div
@@ -75,6 +130,10 @@ const HistoryView: React.FC = () => {
               {item.url}
               <br />
               {new Date(item.visitTime).toLocaleString()}
+              <br />
+              <span style={{ color: '#888' }}>
+                {item.platform} • {item.browserName}
+              </span>
             </div>
           </div>
         ))}


### PR DESCRIPTION
This PR adds filtering capabilities for device/OS in the history view.

### Changes
- Add platform and browser dropdown filters to history view
- Show device and browser information for each history entry
- Enhance search functionality to filter by platform and browser type
- Add styles for new filter controls

### Features
- Filter history by specific devices/OS
- Filter by browser type
- Combine filters with text search
- See device/browser information for each entry

### Testing
1. Open the history view
2. Use the new dropdown filters to filter by platform or browser
3. Try combining filters with the text search
4. Verify that the device/browser information is shown for each entry