### PR TITLE
Add OpenRouter integration for webpage summarization

### DIFF
--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -125,6 +125,44 @@ describe('Settings', () => {
     customUrlContainer.appendChild(customApiUrlInput);
     
     form.appendChild(customUrlContainer);
+
+    // OpenRouter API key input
+    const openRouterApiKey = document.createElement('input');
+    openRouterApiKey.id = 'openRouterApiKey';
+    openRouterApiKey.type = 'password';
+    form.appendChild(openRouterApiKey);
+
+    // Model select
+    const selectedModel = document.createElement('select');
+    selectedModel.id = 'selectedModel';
+    const modelOption = document.createElement('option');
+    modelOption.value = 'anthropic/claude-2';
+    modelOption.textContent = 'Claude 2';
+    selectedModel.appendChild(modelOption);
+    form.appendChild(selectedModel);
+
+    // Model info container
+    const modelInfo = document.createElement('div');
+    modelInfo.id = 'modelInfo';
+    modelInfo.style.display = 'none';
+    
+    const modelDescription = document.createElement('p');
+    modelDescription.className = 'model-description';
+    modelInfo.appendChild(modelDescription);
+
+    const modelStats = document.createElement('div');
+    modelStats.className = 'model-stats';
+    
+    const contextLength = document.createElement('span');
+    contextLength.className = 'context-length';
+    modelStats.appendChild(contextLength);
+
+    const pricing = document.createElement('span');
+    pricing.className = 'pricing';
+    modelStats.appendChild(pricing);
+
+    modelInfo.appendChild(modelStats);
+    form.appendChild(modelInfo);
     mockContainer.appendChild(form);
 
     // Add settings actions container with buttons
@@ -153,7 +191,9 @@ describe('Settings', () => {
         mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
         clientId: 'test-client',
         environment: 'production',
-        customApiUrl: null
+        customApiUrl: null,
+        openRouterApiKey: '',
+        selectedModel: ''
       });
     });
 
@@ -176,7 +216,9 @@ describe('Settings', () => {
       mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
       clientId: 'test-client',
       customApiUrl: 'http://test-api.com',
-      environment: 'custom'
+      environment: 'custom',
+      openRouterApiKey: '',
+      selectedModel: 'anthropic/claude-2'
     };
 
     chrome.storage.sync.get.mockImplementation((keys, callback) => {
@@ -197,7 +239,9 @@ describe('Settings', () => {
       mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
       clientId: 'new-client',
       customApiUrl: 'http://new-api.com',
-      environment: 'custom'
+      environment: 'custom',
+      openRouterApiKey: 'test-key',
+      selectedModel: 'anthropic/claude-2'
     };
 
     // Mock generateClientId to return the expected client ID
@@ -209,6 +253,8 @@ describe('Settings', () => {
     document.getElementById('clientId').value = newConfig.clientId;
     document.getElementById('environment').value = newConfig.environment;
     document.getElementById('customApiUrl').value = newConfig.customApiUrl;
+    document.getElementById('openRouterApiKey').value = newConfig.openRouterApiKey;
+    document.getElementById('selectedModel').value = newConfig.selectedModel;
 
     const mockEvent = {
       preventDefault: vi.fn()

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -29,6 +29,7 @@
   "host_permissions": [
     "http://localhost:*/*",
     "https://api.chroniclesync.xyz/*",
-    "https://api-staging.chroniclesync.xyz/*"
+    "https://api-staging.chroniclesync.xyz/*",
+    "https://openrouter.ai/api/*"
   ]
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -45,3 +45,26 @@ body {
 .action-buttons button:hover {
   background-color: #e0e0e0;
 }
+
+.summary {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.summary h3 {
+  margin: 0 0 10px 0;
+  color: #343a40;
+  font-size: 16px;
+}
+
+.summary p {
+  margin: 0;
+  color: #495057;
+  font-size: 14px;
+  line-height: 1.5;
+}

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -38,6 +38,28 @@
             </div>
         </section>
 
+        <section class="settings-section">
+            <h2>OpenRouter Configuration</h2>
+            <div class="setting-item">
+                <label for="openRouterApiKey">OpenRouter API Key:</label>
+                <input type="password" id="openRouterApiKey" placeholder="Enter your OpenRouter API key">
+                <small class="help-text">Get your API key from <a href="https://openrouter.ai/keys" target="_blank">OpenRouter</a></small>
+            </div>
+            <div class="setting-item">
+                <label for="selectedModel">Model:</label>
+                <select id="selectedModel" required>
+                    <option value="anthropic/claude-2">Claude 2</option>
+                    <option value="anthropic/claude-instant-v1">Claude Instant</option>
+                    <option value="google/palm-2-chat-bison">PaLM 2 Chat</option>
+                    <option value="meta-llama/llama-2-70b-chat">Llama 2 70B Chat</option>
+                    <option value="mistral-ai/mistral-7b-instruct">Mistral 7B Instruct</option>
+                    <option value="openai/gpt-3.5-turbo">GPT-3.5 Turbo</option>
+                    <option value="openai/gpt-4">GPT-4</option>
+                </select>
+                <small class="help-text">Select the model to use for summarization</small>
+            </div>
+        </section>
+
         <div class="settings-actions">
             <button id="saveSettings" class="primary-button">Save Settings</button>
             <button id="resetSettings" class="reset-settings">Reset to Default</button>

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -48,14 +48,15 @@
             <div class="setting-item">
                 <label for="selectedModel">Model:</label>
                 <select id="selectedModel" required>
-                    <option value="anthropic/claude-2">Claude 2</option>
-                    <option value="anthropic/claude-instant-v1">Claude Instant</option>
-                    <option value="google/palm-2-chat-bison">PaLM 2 Chat</option>
-                    <option value="meta-llama/llama-2-70b-chat">Llama 2 70B Chat</option>
-                    <option value="mistral-ai/mistral-7b-instruct">Mistral 7B Instruct</option>
-                    <option value="openai/gpt-3.5-turbo">GPT-3.5 Turbo</option>
-                    <option value="openai/gpt-4">GPT-4</option>
+                    <option value="">Loading models...</option>
                 </select>
+                <div id="modelInfo" class="model-info" style="display: none;">
+                    <p class="model-description"></p>
+                    <div class="model-stats">
+                        <span class="context-length"></span>
+                        <span class="pricing"></span>
+                    </div>
+                </div>
                 <small class="help-text">Select the model to use for summarization</small>
             </div>
         </section>

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,13 +1,16 @@
 import { Settings } from './settings/Settings';
 import { HistorySync } from './services/HistorySync';
+import { OpenRouter } from './services/OpenRouter';
 
 export class BackgroundService {
   private settings: Settings;
   private historySync: HistorySync;
+  private openRouter: OpenRouter;
 
   constructor() {
     this.settings = new Settings();
     this.historySync = new HistorySync(this.settings);
+    this.openRouter = new OpenRouter(this.settings);
   }
 
   async init(): Promise<void> {
@@ -40,7 +43,7 @@ export class BackgroundService {
       }
 
       // Handle asynchronous operations
-      if (request.type === 'getHistory' || request.type === 'startSync') {
+      if (request.type === 'getHistory' || request.type === 'startSync' || request.type === 'summarizeText') {
         // Create a promise to handle the async operation
         const asyncOperation = async () => {
           try {
@@ -51,6 +54,9 @@ export class BackgroundService {
             } else if (request.type === 'startSync') {
               await this.historySync.startSync();
               sendResponse({ success: true });
+            } else if (request.type === 'summarizeText') {
+              const summary = await this.openRouter.summarizeText(request.text);
+              sendResponse({ summary });
             }
           } catch (error) {
             handleError(error);

--- a/extension/src/services/OpenRouter.ts
+++ b/extension/src/services/OpenRouter.ts
@@ -1,0 +1,87 @@
+import { Settings } from '../settings/Settings';
+
+interface OpenRouterModel {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number;
+  pricing: {
+    prompt: number;
+    completion: number;
+  };
+}
+
+interface OpenRouterResponse {
+  choices: {
+    message: {
+      content: string;
+    };
+  }[];
+}
+
+export class OpenRouter {
+  private readonly OPENROUTER_API_URL = 'https://openrouter.ai/api/v1';
+  private settings: Settings;
+
+  constructor(settings: Settings) {
+    this.settings = settings;
+  }
+
+  private async fetchWithAuth(endpoint: string, options: RequestInit = {}): Promise<Response> {
+    const apiKey = await this.settings.getOpenRouterApiKey();
+    if (!apiKey) {
+      throw new Error('OpenRouter API key not configured');
+    }
+
+    const headers = {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': chrome.runtime.getURL(''),
+      'X-Title': 'ChronicleSync'
+    };
+
+    return fetch(`${this.OPENROUTER_API_URL}${endpoint}`, {
+      ...options,
+      headers: {
+        ...headers,
+        ...options.headers
+      }
+    });
+  }
+
+  async getAvailableModels(): Promise<OpenRouterModel[]> {
+    const response = await this.fetchWithAuth('/models');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch models: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data.data;
+  }
+
+  async summarizeText(text: string): Promise<string> {
+    const model = await this.settings.getSelectedModel();
+    const response = await this.fetchWithAuth('/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: model,
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a helpful assistant that summarizes text content. Provide concise, informative summaries that capture the key points.'
+          },
+          {
+            role: 'user',
+            content: `Please summarize the following text:\n\n${text}`
+          }
+        ]
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to summarize text: ${response.statusText}`);
+    }
+
+    const data = await response.json() as OpenRouterResponse;
+    return data.choices[0].message.content;
+  }
+}

--- a/extension/src/services/OpenRouter.ts
+++ b/extension/src/services/OpenRouter.ts
@@ -9,6 +9,13 @@ interface OpenRouterModel {
     prompt: number;
     completion: number;
   };
+  top_provider?: {
+    max_completion_tokens?: number;
+    max_context_tokens?: number;
+    max_parallel_requests?: number;
+    max_requests_per_min?: number;
+    max_tokens_per_min?: number;
+  };
 }
 
 interface OpenRouterResponse {

--- a/extension/src/settings/Settings.ts
+++ b/extension/src/settings/Settings.ts
@@ -90,7 +90,7 @@ export class Settings {
 
   private async getStorageData(): Promise<Partial<SettingsConfig>> {
     return new Promise((resolve) => {
-      const keys: StorageKeys[] = ['mnemonic', 'clientId', 'customApiUrl', 'environment'];
+      const keys: StorageKeys[] = ['mnemonic', 'clientId', 'customApiUrl', 'environment', 'openRouterApiKey', 'selectedModel'];
       chrome.storage.sync.get(keys, (result) => resolve(result as Partial<SettingsConfig>));
     });
   }
@@ -118,11 +118,15 @@ export class Settings {
     const environmentSelect = document.getElementById('environment') as HTMLSelectElement;
     const customUrlContainer = document.getElementById('customUrlContainer') as HTMLDivElement;
     const customApiUrlInput = document.getElementById('customApiUrl') as HTMLInputElement;
+    const openRouterApiKey = document.getElementById('openRouterApiKey') as HTMLInputElement;
+    const selectedModel = document.getElementById('selectedModel') as HTMLSelectElement;
 
     mnemonicInput.value = this.config.mnemonic;
     clientIdInput.value = this.config.clientId;
     environmentSelect.value = this.config.environment;
     customApiUrlInput.value = this.config.customApiUrl || '';
+    openRouterApiKey.value = this.config.openRouterApiKey || '';
+    selectedModel.value = this.config.selectedModel || this.DEFAULT_SETTINGS.selectedModel;
     
     customUrlContainer.style.display = this.config.environment === 'custom' ? 'block' : 'none';
   }
@@ -196,11 +200,16 @@ export class Settings {
     const clientId = await this.generateClientId(mnemonic);
     clientIdInput.value = clientId;
 
+    const openRouterApiKey = document.getElementById('openRouterApiKey') as HTMLInputElement;
+    const selectedModel = document.getElementById('selectedModel') as HTMLSelectElement;
+
     const newConfig: SettingsConfig = {
       mnemonic,
       clientId,
       environment: environmentSelect.value as SettingsConfig['environment'],
-      customApiUrl: environmentSelect.value === 'custom' ? customApiUrlInput.value.trim() : null
+      customApiUrl: environmentSelect.value === 'custom' ? customApiUrlInput.value.trim() : null,
+      openRouterApiKey: openRouterApiKey ? openRouterApiKey.value.trim() : '',
+      selectedModel: selectedModel ? selectedModel.value : this.DEFAULT_SETTINGS.selectedModel
     };
 
     if (newConfig.environment === 'custom' && !newConfig.customApiUrl) {

--- a/extension/src/settings/Settings.ts
+++ b/extension/src/settings/Settings.ts
@@ -3,6 +3,8 @@ interface SettingsConfig {
   clientId: string;
   customApiUrl: string | null;
   environment: 'production' | 'staging' | 'custom';
+  openRouterApiKey: string;
+  selectedModel: string;
 }
 
 type StorageKeys = keyof SettingsConfig;
@@ -17,7 +19,9 @@ export class Settings {
     mnemonic: '',
     clientId: '',
     customApiUrl: null,
-    environment: 'production'
+    environment: 'production',
+    openRouterApiKey: '',
+    selectedModel: 'anthropic/claude-2'
   };
 
   async init(): Promise<void> {
@@ -34,7 +38,9 @@ export class Settings {
       mnemonic: result.mnemonic || this.DEFAULT_SETTINGS.mnemonic,
       clientId: result.clientId || this.DEFAULT_SETTINGS.clientId,
       customApiUrl: result.customApiUrl || this.DEFAULT_SETTINGS.customApiUrl,
-      environment: result.environment || this.DEFAULT_SETTINGS.environment
+      environment: result.environment || this.DEFAULT_SETTINGS.environment,
+      openRouterApiKey: result.openRouterApiKey || this.DEFAULT_SETTINGS.openRouterApiKey,
+      selectedModel: result.selectedModel || this.DEFAULT_SETTINGS.selectedModel
     };
 
     // Generate initial mnemonic if needed
@@ -235,5 +241,15 @@ export class Settings {
     setTimeout(() => {
       status.remove();
     }, 3000);
+  }
+
+  async getOpenRouterApiKey(): Promise<string> {
+    if (!this.config) throw new Error('Settings not initialized');
+    return this.config.openRouterApiKey;
+  }
+
+  async getSelectedModel(): Promise<string> {
+    if (!this.config) throw new Error('Settings not initialized');
+    return this.config.selectedModel;
   }
 }


### PR DESCRIPTION
This PR adds OpenRouter integration to the ChronicleSync extension, enabling AI-powered webpage summarization.

### Changes
- Add OpenRouter service class for API interactions
- Add settings for OpenRouter API key and model selection
- Add summarize button to popup interface
- Support multiple OpenRouter models (Claude 2, GPT-4, PaLM 2, etc.)
- Add styling for summary display

### Features
- Configure OpenRouter API key and model in settings
- Summarize webpage content using selected AI model
- Display summaries in a scrollable section
- Support for multiple OpenRouter models

### Usage
1. Configure OpenRouter API key in extension settings
2. Select preferred model
3. Navigate to any webpage
4. Click extension icon and "Summarize Page"
5. View summary in popup window

The extension will use article content if available, otherwise using the entire page content.