### PR TITLE
fix: Change let to const in history-view.spec.ts

### DIFF
--- a/extension/e2e/history-view.spec.ts
+++ b/extension/e2e/history-view.spec.ts
@@ -124,8 +124,8 @@ test.describe('History View', () => {
     await settingsPage.waitForTimeout(1000);
 
     // Generate and save client ID if needed
-    let mnemonic = await settingsPage.locator('#mnemonic').inputValue();
-    let clientId = await settingsPage.locator('#clientId').inputValue();
+    const mnemonic = await settingsPage.locator('#mnemonic').inputValue();
+    const clientId = await settingsPage.locator('#clientId').inputValue();
     if (!mnemonic || !clientId) {
       await settingsPage.locator('#generateMnemonic').click();
       await settingsPage.waitForTimeout(1000);


### PR DESCRIPTION
This PR fixes linting errors by changing `let` to `const` in `history-view.spec.ts` where variables are not being reassigned.

### Changes
- Changed `let` to `const` for `mnemonic` and `clientId` variables in the second test case where they are not being reassigned
- Left the first occurrence of `let` unchanged as those variables are reassigned within a loop

### Testing
✅ Build successful
✅ All tests passing
⚠️ Lint shows only console.log warnings (acceptable for test files)

This PR is based on the `remove-history-limit` branch.