### PR TITLE
Add customizable history expiration feature

### DIFF
--- a/extension/settings.html
+++ b/extension/settings.html
@@ -36,6 +36,11 @@
                 <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
                 <small class="help-text">Only used when Environment is set to Custom</small>
             </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
         </section>
 
         <div class="settings-actions">


### PR DESCRIPTION
This PR adds a customizable history expiration feature that allows users to control how long their history is kept before expiring.

### Changes
- Add expiration days setting with a default of 7 days
- Add UI control in settings page for configuring expiration days
- Implement expiration filtering in history sync and retrieval
- Add validation to ensure expiration days is at least 1

### Implementation Details
- Added `expirationDays` to Settings configuration
- Modified HistorySync to respect expiration setting in:
  - Initial history loading
  - Syncing pending entries
  - Getting history entries
- Added input validation and error messages
- Updated UI to include expiration days setting

### Testing
- Tested with default 7-day setting
- Tested with custom expiration periods
- Verified expiration filtering works in all history operations
- Verified input validation for expiration days