### PR TITLE
Fix settings component tests

### DIFF
--- a/extension/__tests__/settings.extension.test.js
+++ b/extension/__tests__/settings.extension.test.js
@@ -124,6 +124,14 @@ describe('Settings', () => {
     customApiUrlInput.type = 'url';
     customUrlContainer.appendChild(customApiUrlInput);
     
+    // Expiration days input
+    const expirationDaysInput = document.createElement('input');
+    expirationDaysInput.id = 'expirationDays';
+    expirationDaysInput.type = 'number';
+    expirationDaysInput.min = '1';
+    expirationDaysInput.value = '7';
+    form.appendChild(expirationDaysInput);
+    
     form.appendChild(customUrlContainer);
     mockContainer.appendChild(form);
 
@@ -153,7 +161,8 @@ describe('Settings', () => {
         mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
         clientId: 'test-client',
         environment: 'production',
-        customApiUrl: null
+        customApiUrl: null,
+        expirationDays: 7
       });
     });
 
@@ -176,7 +185,8 @@ describe('Settings', () => {
       mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
       clientId: 'test-client',
       customApiUrl: 'http://test-api.com',
-      environment: 'custom'
+      environment: 'custom',
+      expirationDays: 7
     };
 
     chrome.storage.sync.get.mockImplementation((keys, callback) => {
@@ -197,7 +207,8 @@ describe('Settings', () => {
       mnemonic: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art',
       clientId: 'new-client',
       customApiUrl: 'http://new-api.com',
-      environment: 'custom'
+      environment: 'custom',
+      expirationDays: 7
     };
 
     // Mock generateClientId to return the expected client ID

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -36,6 +36,11 @@
                 <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
                 <small class="help-text">Only used when Environment is set to Custom</small>
             </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
         </section>
 
         <div class="settings-actions">


### PR DESCRIPTION
This PR fixes the failing settings component tests by:

- Adding missing expirationDays input element to test setup
- Adding expirationDays field to all mock configurations
- Updating test cases to include expirationDays field

All tests are now passing.