### PR TITLE
Fix TypeScript imports and build process

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -277,8 +277,8 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         const config = await getConfig();
         if (config.summary?.enabled && config.summary?.autoSummarize) {
           // Import and initialize SummaryService
-          const { SummaryService } = await import('./src/services/SummaryService.js');
-          const { Settings } = await import('./src/settings/Settings.js');
+          const { SummaryService } = await import('./src/services/SummaryService.ts');
+          const { Settings } = await import('./src/settings/Settings.ts');
           
           const settings = new Settings();
           await settings.init();

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -20,7 +20,7 @@ const copyFiles = () => ({
 });
 
 export default defineConfig({
-  plugins: [react(), copyFiles()],
+  plugins: [react()],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
This PR fixes the following issues:

- Updates imports in background.js to use .ts extension for TypeScript files
- Simplifies the build process by removing redundant file copying in vite.config.ts

These changes allow the extension to build successfully and generate the chrome-extension.zip package.