### PR TITLE
Add <all_urls> to host_permissions for content access

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -27,6 +27,7 @@
     "unlimitedStorage"
   ],
   "host_permissions": [
+    "<all_urls>",
     "http://localhost:*/*",
     "https://api.chroniclesync.xyz/*",
     "https://api-staging.chroniclesync.xyz/*"


### PR DESCRIPTION
This PR adds `<all_urls>` to the extension manifest host_permissions to allow content capture from any website for summarization.

**Changes:**
- Added `<all_urls>` to host_permissions in manifest.json
- Kept existing specific permissions for API and localhost access

**Testing:**
- Extension should now be able to capture and summarize content from any website