### PR TITLE
Add Google-style summary previews to history page

### DIFF
--- a/extension/history.css
+++ b/extension/history.css
@@ -53,6 +53,44 @@
   background-color: #f5f5f5;
 }
 
+.history-item-header {
+  margin-bottom: 4px;
+}
+
+.history-item-header a {
+  color: #1a0dab;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.3;
+}
+
+.history-item-header a:hover {
+  text-decoration: underline;
+}
+
+.history-item-summary {
+  color: #4d5156;
+  font-size: 14px;
+  line-height: 1.58;
+  margin: 4px 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.history-item-summary.error {
+  color: #d93025;
+  font-style: italic;
+}
+
+.history-item-meta {
+  color: #70757a;
+  font-size: 12px;
+  display: flex;
+  gap: 12px;
+}
+
 .pagination {
   display: flex;
   justify-content: center;

--- a/extension/src/pages/History.tsx
+++ b/extension/src/pages/History.tsx
@@ -147,6 +147,16 @@ const History: React.FC = () => {
                     ×
                   </button>
                 </div>
+                {entry.summary && entry.summary.status === 'completed' && (
+                  <div className="history-item-summary">
+                    {entry.summary.content}
+                  </div>
+                )}
+                {entry.summaryStatus === 'error' && (
+                  <div className="history-item-summary error">
+                    Failed to generate summary: {entry.summaryError}
+                  </div>
+                )}
                 <div className="history-item-meta">
                   <span className="device-info" title={`${entry.browserName} ${entry.browserVersion}`}>
                     {getDeviceName(entry.deviceId)}


### PR DESCRIPTION
This PR adds Google-style summary previews to the history page, enhancing the user experience by showing content summaries directly in the history view.

### Changes
- Added summary display in the History component with error handling
- Implemented Google-style CSS for summary previews
- Added proper typography and spacing for history items
- Improved visual hierarchy with title, summary, and metadata

### Preview
Summaries now appear under each history item in a Google search result style, with:
- Blue clickable titles
- Two-line truncated summary previews
- Gray metadata text
- Error messages in red italic when summarization fails