### PR TITLE
Fix content extraction error handling

### DIFF
--- a/extension/src/services/SummaryService.ts
+++ b/extension/src/services/SummaryService.ts
@@ -15,9 +15,15 @@ export class SummaryService {
     return this.settings;
   }
 
-  async summarizeContent(url: string, content: { elements: string[] }): Promise<SummaryData> {
+  async summarizeContent(url: string, content: { elements: string[] } | null): Promise<SummaryData> {
     if (!this.settings.enabled) {
       return this.createSummaryData('', 'completed');
+    }
+
+    // Validate content
+    if (!content) {
+      console.error('[Summary] Content is null');
+      return this.createSummaryData('', 'error');
     }
 
     // Check if already processing
@@ -52,7 +58,12 @@ export class SummaryService {
   }
 
   private extractMainContent(content: { elements: string[], stats?: any }): string {
-    if (!content.elements || content.elements.length === 0) {
+    if (!Array.isArray(content.elements)) {
+      console.error('[Summary] Content elements is not an array:', typeof content.elements);
+      throw new Error('Content elements is not an array');
+    }
+
+    if (content.elements.length === 0) {
       console.error('[Summary] No elements found in content');
       throw new Error('No content elements found');
     }


### PR DESCRIPTION
This PR improves error handling in the content extraction process to address the TypeError when accessing content.elements.

Changes:
- Add null check for content object
- Add type check for content.elements array
- Improve error messages for better debugging
- Update type signature to reflect possible null content

This should fix the error:
```
TypeError: Cannot read properties of null (reading elements)
at Rj.extractMainContent (background.js:20242:3180)
```