### PR TITLE
Add transformer.js configuration and CSP headers

### DIFF
--- a/extension/history.html
+++ b/extension/history.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Chronicle Sync History</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' http://localhost:* https://api.chroniclesync.xyz https://api-staging.chroniclesync.xyz https://huggingface.co/; child-src 'self' blob:">
     <link rel="stylesheet" href="history.css" />
   </head>
   <body>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,6 +3,12 @@
   "name": "ChronicleSync Extension",
   "version": "1.0",
   "description": "ChronicleSync Chrome Extension",
+  "cross_origin_embedder_policy": {
+    "value": "require-corp"
+  },
+  "cross_origin_opener_policy": {
+    "value": "same-origin"
+  },
   "action": {
     "default_popup": "popup.html"
   },

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -4,6 +4,7 @@
   <title>ChronicleSync Extension</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src 'self' blob:; connect-src 'self' http://localhost:* https://api.chroniclesync.xyz https://api-staging.chroniclesync.xyz https://huggingface.co/; child-src 'self' blob:">
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
This PR adds the necessary configuration for transformer.js to work in the extension:

- Added COOP and COEP headers in manifest.json to enable SharedArrayBuffer
- Added CSP headers to popup.html and history.html with:
  - wasm-unsafe-eval for WebAssembly execution
  - worker-src for Web Workers
  - connect-src includes huggingface.co for model downloads
  - child-src for blob URLs
  - Required unsafe-eval and unsafe-inline directives

These changes are required to support the local summarization feature using transformer.js.