### PR TITLE
Improve client ID configuration error message

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -45,7 +45,7 @@ async function syncHistory(forceFullSync = false): Promise<void> {
 
     if (!config.clientId || config.clientId === 'extension-default') {
       console.debug('Sync paused: No client ID configured');
-      throw new Error('Please configure your Client ID in the extension popup');
+      throw new Error('No Client ID configured. Please set up your Client ID in the extension settings to start syncing.');
     }
 
     console.debug('Starting sync with client ID:', config.clientId);


### PR DESCRIPTION
This PR improves the error message shown when no client ID is configured.

**Changes:**
- Made the error message more descriptive and user-friendly
- Added specific instructions on how to fix the issue
- Clarified the purpose of setting up the client ID