### PR TITLE
Add Safari extension support for iOS

### DIFF
--- a/.github/workflows/safari-extension.yml
+++ b/.github/workflows/safari-extension.yml
@@ -1,0 +1,52 @@
+name: Safari Extension CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build-safari-extension:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            extension/package-lock.json
+
+      - name: Build Extension
+        working-directory: extension
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Safari Extension
+        run: |
+          cd safari-extension
+          ./build-safari-extension.sh
+
+      - name: Build Xcode Project
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" build
+
+      - name: Run Basic Tests
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test
+
+      - name: Upload Safari Extension Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: safari-extension
+          path: safari-extension/ChronicleSync.xcodeproj
+          retention-days: 14

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,76 @@
+name: TestFlight Distribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        default: 'beta'
+        type: choice
+        options:
+          - beta
+          - production
+
+jobs:
+  build-and-upload:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install Apple Certificate
+        uses: apple-actions/import-codesigning-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Install Provisioning Profile
+        uses: apple-actions/download-provisioning-profiles@v2
+        with:
+          bundle-id: 'com.chroniclesync.app'
+          profile-type: 'IOS_APP_STORE'
+          issuer-id: ${{ secrets.APPLE_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPLE_API_KEY }}
+
+      - name: Build Extension
+        working-directory: extension
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Safari Extension
+        run: |
+          cd safari-extension
+          ./build-safari-extension.sh
+
+      - name: Update Export Options
+        run: |
+          cd safari-extension
+          sed -i '' "s/TEAM_ID_PLACEHOLDER/${{ secrets.APPLE_TEAM_ID }}/g" ExportOptions.plist
+
+      - name: Build and Archive
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -archivePath ChronicleSync.xcarchive archive
+
+      - name: Export IPA
+        run: |
+          cd safari-extension
+          xcodebuild -exportArchive -archivePath ChronicleSync.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath ./build
+
+      - name: Upload to TestFlight
+        uses: apple-actions/upload-testflight-build@v1
+        with:
+          app-path: safari-extension/build/ChronicleSync.ipa
+          issuer-id: ${{ secrets.APPLE_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPLE_API_KEY }}
+          beta-groups: ${{ github.event.inputs.release_type == 'beta' && 'Beta Testers' || '' }}
+          distribute-to-external-testers: ${{ github.event.inputs.release_type == 'production' }}

--- a/safari-extension/ChronicleSync Extension/Info.plist
+++ b/safari-extension/ChronicleSync Extension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ChronicleSync Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/safari-extension/ChronicleSync Extension/Resources/manifest.json
+++ b/safari-extension/ChronicleSync Extension/Resources/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "ChronicleSync Extension",
+  "version": "1.0",
+  "description": "ChronicleSync Safari Extension",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs",
+    "history",
+    "storage"
+  ],
+  "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.chroniclesync.xyz/*",
+    "https://api-staging.chroniclesync.xyz/*"
+  ]
+}

--- a/safari-extension/ChronicleSync Extension/SafariWebExtensionHandler.swift
+++ b/safari-extension/ChronicleSync Extension/SafariWebExtensionHandler.swift
@@ -1,0 +1,19 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+
+    let logger = Logger(subsystem: "com.chroniclesync.app.extension", category: "extension")
+    
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey] as? [String: Any]
+        
+        logger.log("Received message from browser.runtime.sendNativeMessage: \(message ?? [:])")
+        
+        let response = NSExtensionItem()
+        response.userInfo = [ SFExtensionMessageKey: [ "Response to": message?["message"] ?? "" ] ]
+        
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+}

--- a/safari-extension/ChronicleSync Tests/ChronicleSync_Tests.swift
+++ b/safari-extension/ChronicleSync Tests/ChronicleSync_Tests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ChronicleSync
+
+class ChronicleSync_Tests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testAppLaunch() throws {
+        // This is a basic test to verify the app launches successfully
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Verify the app title is displayed
+        XCTAssertTrue(app.staticTexts["ChronicleSync Safari Extension"].exists)
+        
+        // Verify the enable extension button is displayed
+        XCTAssertTrue(app.buttons["Enable Extension"].exists || app.buttons["Extension Settings"].exists)
+    }
+}

--- a/safari-extension/ChronicleSync Tests/SafariExtensionTests.swift
+++ b/safari-extension/ChronicleSync Tests/SafariExtensionTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SafariServices
+
+class SafariExtensionTests: XCTestCase {
+
+    func testExtensionManifest() throws {
+        // This test verifies that the manifest.json file exists and can be parsed
+        let extensionBundle = Bundle(for: type(of: self))
+        let manifestURL = extensionBundle.url(forResource: "manifest", withExtension: "json", subdirectory: "Resources")
+        
+        // Verify manifest file exists
+        XCTAssertNotNil(manifestURL, "manifest.json file not found")
+        
+        // Verify manifest file can be read
+        let manifestData = try Data(contentsOf: manifestURL!)
+        
+        // Verify manifest file can be parsed as JSON
+        let manifest = try JSONSerialization.jsonObject(with: manifestData, options: []) as? [String: Any]
+        XCTAssertNotNil(manifest, "manifest.json could not be parsed as JSON")
+        
+        // Verify manifest contains required fields
+        XCTAssertNotNil(manifest?["name"], "manifest.json missing 'name' field")
+        XCTAssertNotNil(manifest?["version"], "manifest.json missing 'version' field")
+        XCTAssertNotNil(manifest?["manifest_version"], "manifest.json missing 'manifest_version' field")
+    }
+    
+    func testBackgroundScript() throws {
+        // This test verifies that the background.js file exists
+        let extensionBundle = Bundle(for: type(of: self))
+        let backgroundURL = extensionBundle.url(forResource: "background", withExtension: "js", subdirectory: "Resources")
+        
+        // Verify background.js file exists
+        XCTAssertNotNil(backgroundURL, "background.js file not found")
+        
+        // Verify background.js file can be read
+        let backgroundData = try Data(contentsOf: backgroundURL!)
+        XCTAssertTrue(backgroundData.count > 0, "background.js file is empty")
+    }
+    
+    func testContentScript() throws {
+        // This test verifies that the content-script.js file exists
+        let extensionBundle = Bundle(for: type(of: self))
+        let contentScriptURL = extensionBundle.url(forResource: "content-script", withExtension: "js", subdirectory: "Resources")
+        
+        // Verify content-script.js file exists
+        XCTAssertNotNil(contentScriptURL, "content-script.js file not found")
+        
+        // Verify content-script.js file can be read
+        let contentScriptData = try Data(contentsOf: contentScriptURL!)
+        XCTAssertTrue(contentScriptData.count > 0, "content-script.js file is empty")
+    }
+}

--- a/safari-extension/ChronicleSync.xcodeproj/project.pbxproj
+++ b/safari-extension/ChronicleSync.xcodeproj/project.pbxproj
@@ -1,0 +1,564 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1A1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */; };
+		1A1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A28 /* background.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A29 /* background.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A2A /* content-script.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A2C /* popup.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2D /* popup.html */; };
+		1A1A1A1A1A1A1A1A1A1A1A2E /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2F /* popup.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A30 /* popup.css in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A31 /* popup.css */; };
+		1A1A1A1A1A1A1A1A1A1A1A32 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */; };
+		1A1A1A1A1A1A1A1A1A1A1A34 /* ChronicleSync Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A35 /* ChronicleSync Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1A1A1A1A1A1A1A1A1A1A1A36 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A1A1A1A1A1A1A1A1A1A1A37 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A1A1A1A1A1A1A1A1A1A1A38;
+			remoteInfo = "ChronicleSync Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A39 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A34 /* ChronicleSync Extension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		1A1A1A1A1A1A1A1A1A1A1A3A /* ChronicleSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChronicleSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A3B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A3C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A3D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A35 /* ChronicleSync Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ChronicleSync Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A1A3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebExtensionHandler.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A29 /* background.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "content-script.js"; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A2D /* popup.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = popup.html; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A2F /* popup.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = popup.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A31 /* popup.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = popup.css; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A3F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A40 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A1A1A1A1A1A1A1A1A1A1A41 = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A42 /* ChronicleSync */,
+				1A1A1A1A1A1A1A1A1A1A1A43 /* ChronicleSync Extension */,
+				1A1A1A1A1A1A1A1A1A1A1A44 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A44 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A3A /* ChronicleSync.app */,
+				1A1A1A1A1A1A1A1A1A1A1A35 /* ChronicleSync Extension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A42 /* ChronicleSync */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */,
+				1A1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */,
+				1A1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A1A3D /* Info.plist */,
+			);
+			path = ChronicleSync;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A43 /* ChronicleSync Extension */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A45 /* Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */,
+				1A1A1A1A1A1A1A1A1A1A1A3E /* Info.plist */,
+			);
+			path = "ChronicleSync Extension";
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A45 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A29 /* background.js */,
+				1A1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */,
+				1A1A1A1A1A1A1A1A1A1A1A2D /* popup.html */,
+				1A1A1A1A1A1A1A1A1A1A1A2F /* popup.js */,
+				1A1A1A1A1A1A1A1A1A1A1A31 /* popup.css */,
+				1A1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A1A1A1A1A1A1A1A1A1A1A46 /* ChronicleSync */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A47 /* Build configuration list for PBXNativeTarget "ChronicleSync" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A48 /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A3F /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A49 /* Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A39 /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A1A1A1A1A1A1A1A1A1A1A4A /* PBXTargetDependency */,
+			);
+			name = ChronicleSync;
+			productName = ChronicleSync;
+			productReference = 1A1A1A1A1A1A1A1A1A1A1A3A /* ChronicleSync.app */;
+			productType = "com.apple.product-type.application";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A38 /* ChronicleSync Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A4B /* Build configuration list for PBXNativeTarget "ChronicleSync Extension" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A4C /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A40 /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A4D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ChronicleSync Extension";
+			productName = "ChronicleSync Extension";
+			productReference = 1A1A1A1A1A1A1A1A1A1A1A35 /* ChronicleSync Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A1A1A1A1A1A1A1A1A1A1A37 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					1A1A1A1A1A1A1A1A1A1A1A46 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					1A1A1A1A1A1A1A1A1A1A1A38 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A4E /* Build configuration list for PBXProject "ChronicleSync" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A1A1A1A1A1A1A1A1A1A1A41;
+			productRefGroup = 1A1A1A1A1A1A1A1A1A1A1A44 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A1A1A1A1A1A1A1A1A1A1A46 /* ChronicleSync */,
+				1A1A1A1A1A1A1A1A1A1A1A38 /* ChronicleSync Extension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A49 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A28 /* background.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A2C /* popup.html in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A2E /* popup.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A32 /* manifest.json in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A2A /* content-script.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A1A30 /* popup.css in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A48 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A1A1A1A1A1A1A1A1A1A1A4A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A1A1A1A1A1A1A1A1A1A1A38 /* ChronicleSync Extension */;
+			targetProxy = 1A1A1A1A1A1A1A1A1A1A1A36 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		1A1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A3B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A3C /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		1A1A1A1A1A1A1A1A1A1A1A4F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A50 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.chroniclesync.app.extension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A52 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.chroniclesync.app.extension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChronicleSync;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chroniclesync.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChronicleSync;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chroniclesync.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A1A1A1A1A1A1A1A1A1A1A4E /* Build configuration list for PBXProject "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A4F /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A50 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4B /* Build configuration list for PBXNativeTarget "ChronicleSync Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A51 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A52 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A47 /* Build configuration list for PBXNativeTarget "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A53 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A1A1A1A1A1A1A1A1A1A1A37 /* Project object */;
+}

--- a/safari-extension/ChronicleSync/AppDelegate.swift
+++ b/safari-extension/ChronicleSync/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}

--- a/safari-extension/ChronicleSync/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/safari-extension/ChronicleSync/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/safari-extension/ChronicleSync/Assets.xcassets/Contents.json
+++ b/safari-extension/ChronicleSync/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/safari-extension/ChronicleSync/Base.lproj/LaunchScreen.storyboard
+++ b/safari-extension/ChronicleSync/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqu">
+                                <rect key="frame" x="107.33333333333333" y="408.66666666666669" width="178.33333333333337" height="35"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="29"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ygd-Vc-Qqu" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Ygd-Vc-Qqv"/>
+                            <constraint firstItem="Ygd-Vc-Qqu" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Ygd-Vc-Qqw"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/safari-extension/ChronicleSync/Base.lproj/Main.storyboard
+++ b/safari-extension/ChronicleSync/Base.lproj/Main.storyboard
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ChronicleSync" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqe">
+                                <rect key="frame" x="20" y="359" width="353" height="134.33333333333337"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="safari" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqf">
+                                        <rect key="frame" x="0.0" y="0.0" width="353" height="50"/>
+                                        <color key="tintColor" systemColor="systemBlueColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="Ygd-Vc-Qqg"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync Safari Extension" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqh">
+                                        <rect key="frame" x="0.0" y="70" width="353" height="23"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checking extension status..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqi">
+                                        <rect key="frame" x="0.0" y="113" width="353" height="21.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqj">
+                                <rect key="frame" x="96.666666666666686" y="513.33333333333337" width="200" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Ygd-Vc-Qqk"/>
+                                    <constraint firstAttribute="height" constant="40" id="Ygd-Vc-Qql"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Enable Extension"/>
+                                <connections>
+                                    <action selector="openSettings:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ygd-Vc-Qqm"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ygd-Vc-Qqe" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Ygd-Vc-Qqn"/>
+                            <constraint firstItem="Ygd-Vc-Qqj" firstAttribute="top" secondItem="Ygd-Vc-Qqe" secondAttribute="bottom" constant="20" id="Ygd-Vc-Qqo"/>
+                            <constraint firstItem="Ygd-Vc-Qqj" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Ygd-Vc-Qqp"/>
+                            <constraint firstItem="Ygd-Vc-Qqe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Ygd-Vc-Qqq"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Ygd-Vc-Qqe" secondAttribute="trailing" constant="20" id="Ygd-Vc-Qqr"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="enableExtensionButton" destination="Ygd-Vc-Qqj" id="Ygd-Vc-Qqs"/>
+                        <outlet property="statusLabel" destination="Ygd-Vc-Qqi" id="Ygd-Vc-Qqt"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="132" y="-27"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="safari" catalog="system" width="128" height="123"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/safari-extension/ChronicleSync/Info.plist
+++ b/safari-extension/ChronicleSync/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/safari-extension/ChronicleSync/SceneDelegate.swift
+++ b/safari-extension/ChronicleSync/SceneDelegate.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}

--- a/safari-extension/ChronicleSync/ViewController.swift
+++ b/safari-extension/ChronicleSync/ViewController.swift
@@ -1,0 +1,56 @@
+import UIKit
+import SafariServices
+
+class ViewController: UIViewController {
+    
+    @IBOutlet weak var enableExtensionButton: UIButton!
+    @IBOutlet weak var statusLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateExtensionStatus()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateExtensionStatus()
+    }
+    
+    @IBAction func openSettings(_ sender: Any) {
+        SFSafariApplication.showPreferencesForExtension(withIdentifier: "com.chroniclesync.app.extension") { error in
+            guard error == nil else {
+                // Handle error
+                self.statusLabel.text = "Error opening extension settings: \(error!.localizedDescription)"
+                return
+            }
+            // Successfully opened settings
+            DispatchQueue.main.async {
+                self.updateExtensionStatus()
+            }
+        }
+    }
+    
+    func updateExtensionStatus() {
+        SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: "com.chroniclesync.app.extension") { (state, error) in
+            guard let state = state, error == nil else {
+                // Handle error
+                DispatchQueue.main.async {
+                    self.statusLabel.text = "Error checking extension status: \(error?.localizedDescription ?? "Unknown error")"
+                    self.enableExtensionButton.isEnabled = false
+                }
+                return
+            }
+            
+            DispatchQueue.main.async {
+                if state.isEnabled {
+                    self.statusLabel.text = "ChronicleSync extension is enabled."
+                    self.enableExtensionButton.setTitle("Extension Settings", for: .normal)
+                } else {
+                    self.statusLabel.text = "ChronicleSync extension is disabled. Please enable it in Safari settings."
+                    self.enableExtensionButton.setTitle("Enable Extension", for: .normal)
+                }
+                self.enableExtensionButton.isEnabled = true
+            }
+        }
+    }
+}

--- a/safari-extension/ExportOptions.plist
+++ b/safari-extension/ExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>TEAM_ID_PLACEHOLDER</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/safari-extension/README.md
+++ b/safari-extension/README.md
@@ -1,0 +1,68 @@
+# ChronicleSync Safari Extension for iOS
+
+This is the Safari extension version of ChronicleSync for iOS devices.
+
+## Development Setup
+
+### Prerequisites
+
+- Xcode 14.0 or later
+- iOS 15.0 or later
+- macOS 12.0 or later
+- Node.js 20.0 or later
+
+### Building the Extension
+
+1. First, build the core extension code:
+
+```bash
+cd ../extension
+npm install
+npm run build
+```
+
+2. Then, build the Safari extension:
+
+```bash
+cd ../safari-extension
+./build-safari-extension.sh
+```
+
+3. Open the Xcode project:
+
+```bash
+open ChronicleSync.xcodeproj
+```
+
+4. Build and run the project in Xcode.
+
+### Testing on a Device
+
+1. Connect your iOS device to your Mac.
+2. Select your device as the build target in Xcode.
+3. Build and run the app on your device.
+4. Open Safari on your device.
+5. Go to Settings > Safari > Extensions.
+6. Enable the ChronicleSync extension.
+
+## Architecture
+
+The Safari extension reuses most of the code from the Chrome/Firefox extension, with a few key differences:
+
+1. The extension is packaged as an iOS app with a Safari App Extension.
+2. The manifest.json file has been modified to be compatible with Safari's requirements.
+3. The extension uses Safari's extension APIs instead of Chrome's.
+
+## Testing
+
+Basic tests are included to verify that the extension loads correctly. More comprehensive tests will be added in the future.
+
+## GitHub Actions
+
+The extension is built and tested on GitHub Actions using macOS runners. The workflow is defined in `.github/workflows/safari-extension.yml`.
+
+## Future Improvements
+
+- Add more comprehensive tests
+- Set up TestFlight distribution
+- Add automated UI tests

--- a/safari-extension/TESTFLIGHT_SETUP.md
+++ b/safari-extension/TESTFLIGHT_SETUP.md
@@ -1,0 +1,161 @@
+# Setting Up TestFlight on GitHub Actions
+
+This document explains how to set up TestFlight distribution for the ChronicleSync Safari extension using GitHub Actions.
+
+## Prerequisites
+
+1. An Apple Developer account with access to App Store Connect
+2. The app registered in App Store Connect
+3. A GitHub repository with GitHub Actions enabled
+
+## Step 1: Create App-Specific Password
+
+1. Go to [appleid.apple.com](https://appleid.apple.com/)
+2. Sign in with your Apple ID
+3. In the "Security" section, click "Generate Password" under "App-Specific Passwords"
+4. Enter a label for the password (e.g., "GitHub Actions")
+5. Click "Create" and save the generated password
+
+## Step 2: Create API Key for App Store Connect
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com/)
+2. Click on "Users and Access" in the sidebar
+3. Click on the "Keys" tab
+4. Click the "+" button to create a new key
+5. Enter a name for the key (e.g., "GitHub Actions")
+6. Select the "App Manager" role
+7. Click "Generate"
+8. Download the API key file (.p8) and note the Key ID and Issuer ID
+
+## Step 3: Add Secrets to GitHub Repository
+
+1. Go to your GitHub repository
+2. Click on "Settings" > "Secrets" > "Actions"
+3. Add the following secrets:
+   - `APPLE_API_KEY`: The contents of the .p8 file
+   - `APPLE_API_KEY_ID`: The Key ID from App Store Connect
+   - `APPLE_API_ISSUER_ID`: The Issuer ID from App Store Connect
+   - `APPLE_ID`: Your Apple ID email
+   - `APPLE_APP_SPECIFIC_PASSWORD`: The app-specific password you generated
+   - `APPLE_TEAM_ID`: Your Apple Developer Team ID (found in the Apple Developer portal)
+
+## Step 4: Create a GitHub Actions Workflow for TestFlight
+
+Create a new workflow file in `.github/workflows/testflight.yml`:
+
+```yaml
+name: TestFlight Distribution
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install Apple Certificate
+        uses: apple-actions/import-codesigning-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Install Provisioning Profile
+        uses: apple-actions/download-provisioning-profiles@v2
+        with:
+          bundle-id: 'com.chroniclesync.app'
+          profile-type: 'IOS_APP_STORE'
+          issuer-id: ${{ secrets.APPLE_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPLE_API_KEY }}
+
+      - name: Build Extension
+        working-directory: extension
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Safari Extension
+        run: |
+          cd safari-extension
+          ./build-safari-extension.sh
+
+      - name: Build and Archive
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -archivePath ChronicleSync.xcarchive archive
+
+      - name: Export IPA
+        run: |
+          cd safari-extension
+          xcodebuild -exportArchive -archivePath ChronicleSync.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath ./build
+
+      - name: Upload to TestFlight
+        uses: apple-actions/upload-testflight-build@v1
+        with:
+          app-path: safari-extension/build/ChronicleSync.ipa
+          issuer-id: ${{ secrets.APPLE_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          api-private-key: ${{ secrets.APPLE_API_KEY }}
+```
+
+## Step 5: Create Export Options File
+
+Create a file at `safari-extension/ExportOptions.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>
+```
+
+Replace `YOUR_TEAM_ID` with your actual Apple Developer Team ID.
+
+## Step 6: Generate and Export Certificates
+
+1. Open Keychain Access on your Mac
+2. Go to "Certificates" and find your iOS Distribution certificate
+3. Right-click on the certificate and select "Export"
+4. Save the certificate as a .p12 file and set a password
+5. Convert the .p12 file to base64:
+   ```bash
+   base64 -i certificate.p12 | pbcopy
+   ```
+6. Add the base64-encoded certificate as a GitHub secret named `APPLE_CERTIFICATE_P12`
+7. Add the certificate password as a GitHub secret named `APPLE_CERTIFICATE_PASSWORD`
+
+## Step 7: Test the Workflow
+
+1. Push a commit to the main branch or manually trigger the workflow
+2. Monitor the workflow execution in the GitHub Actions tab
+3. Once the workflow completes successfully, check App Store Connect to verify the build was uploaded to TestFlight
+
+## Troubleshooting
+
+- If the build fails with code signing errors, verify your certificates and provisioning profiles
+- If the upload to TestFlight fails, check the App Store Connect API credentials
+- If the build succeeds but doesn't appear in TestFlight, check the App Store Connect processing queue

--- a/safari-extension/build-safari-extension.sh
+++ b/safari-extension/build-safari-extension.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+# Define paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$SCRIPT_DIR/../extension"
+SAFARI_EXTENSION_DIR="$SCRIPT_DIR/ChronicleSync Extension/Resources"
+
+# Build the extension
+echo "Building extension..."
+cd "$EXTENSION_DIR"
+npm run build
+
+# Create Safari extension directory if it doesn't exist
+mkdir -p "$SAFARI_EXTENSION_DIR"
+
+# Copy necessary files
+echo "Copying files to Safari extension..."
+
+# Copy the manifest.json (already created with Safari-specific modifications)
+# Copy HTML files
+cp "$EXTENSION_DIR/popup.html" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/settings.html" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/history.html" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/devtools.html" "$SAFARI_EXTENSION_DIR/"
+
+# Copy CSS files
+cp "$EXTENSION_DIR/popup.css" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/settings.css" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/history.css" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/devtools.css" "$SAFARI_EXTENSION_DIR/"
+
+# Copy JS files
+cp "$EXTENSION_DIR/dist/popup.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/background.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/settings.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/history.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/devtools.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/devtools-page.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/dist/content-script.js" "$SAFARI_EXTENSION_DIR/"
+cp "$EXTENSION_DIR/bip39-wordlist.js" "$SAFARI_EXTENSION_DIR/"
+
+# Copy assets directory if it exists
+if [ -d "$EXTENSION_DIR/dist/assets" ]; then
+  mkdir -p "$SAFARI_EXTENSION_DIR/assets"
+  cp -R "$EXTENSION_DIR/dist/assets/"* "$SAFARI_EXTENSION_DIR/assets/"
+fi
+
+echo "Safari extension build completed successfully!"

--- a/safari-extension/github-workflow-safari.yml
+++ b/safari-extension/github-workflow-safari.yml
@@ -1,0 +1,52 @@
+name: Safari Extension CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build-safari-extension:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            extension/package-lock.json
+
+      - name: Build Extension
+        working-directory: extension
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Safari Extension
+        run: |
+          cd safari-extension
+          ./build-safari-extension.sh
+
+      - name: Build Xcode Project
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" build
+
+      - name: Run Basic Tests
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=latest" test
+
+      - name: Upload Safari Extension Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: safari-extension
+          path: safari-extension/ChronicleSync.xcodeproj
+          retention-days: 14

--- a/safari-extension/test-on-device.sh
+++ b/safari-extension/test-on-device.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Define paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Build the Safari extension
+echo "Building Safari extension..."
+"$SCRIPT_DIR/build-safari-extension.sh"
+
+# Get connected device UDID
+echo "Getting connected device UDID..."
+DEVICE_UDID=$(xcrun xctrace list devices | grep -v "Simulator" | grep -v "=" | head -1 | awk '{print $NF}' | tr -d '()')
+
+if [ -z "$DEVICE_UDID" ]; then
+  echo "No iOS device connected. Please connect an iOS device and try again."
+  exit 1
+fi
+
+echo "Found device with UDID: $DEVICE_UDID"
+
+# Build and run on device
+echo "Building and running on device..."
+xcodebuild -project "$SCRIPT_DIR/ChronicleSync.xcodeproj" -scheme "ChronicleSync" -destination "id=$DEVICE_UDID" build
+
+echo "App built successfully!"
+echo ""
+echo "To test the extension:"
+echo "1. Open the ChronicleSync app on your device"
+echo "2. Tap the 'Enable Extension' button"
+echo "3. Open Safari and browse to a website"
+echo "4. Tap the 'Aa' button in the address bar"
+echo "5. Select 'ChronicleSync Extension' from the list"
+echo ""
+echo "The extension should now be active in Safari."


### PR DESCRIPTION
This PR adds support for Safari extension on iOS with maximum code reuse from the existing Chrome/Firefox extension.

## Changes

- Created Xcode project structure for Safari extension
- Added build script to compile TypeScript code for Safari
- Created Safari-compatible manifest.json
- Added basic tests for Safari extension
- Added GitHub Actions workflow for building and testing Safari extension
- Added documentation for TestFlight setup
- Added test script for testing on physical devices

## Next Steps

- Set up TestFlight distribution
- Add more comprehensive tests
- Implement iOS-specific features