### PR TITLE
Safari Extension Documentation and Setup Guide

### DIFF
--- a/safari-extension-branch-comparison.md
+++ b/safari-extension-branch-comparison.md
@@ -1,0 +1,84 @@
+# Comparison: Main Branch vs. add-safari-extension Branch
+
+This document outlines the key differences between the `main` branch and the `add-safari-extension` branch of the ChronicleSync repository.
+
+## Added Files and Directories
+
+The `add-safari-extension` branch adds the following new files and directories:
+
+### Safari Extension Structure
+- `extension/safari/` - Main directory for Safari extension
+- `extension/safari/ChronicleSync/` - Xcode project directory
+- `extension/safari/ChronicleSync/ChronicleSync/` - Host app for the extension
+- `extension/safari/ChronicleSync/ChronicleSync Extension/` - Safari extension implementation
+- `extension/safari/ChronicleSync/ChronicleSync Tests/` - Unit tests
+- `extension/safari/ChronicleSync/ChronicleSync UITests/` - UI tests
+- `extension/safari/README.md` - Documentation for the Safari extension
+
+### Build Scripts
+- `extension/scripts/build-safari-extension.sh` - Script to build the Safari extension
+
+### Configuration Files
+- `extension/safari/ChronicleSync/ChronicleSync Extension/Resources/manifest.json` - Web Extension manifest
+- `extension/safari/ChronicleSync/ChronicleSync Extension/ChronicleSync_Extension.entitlements` - Extension entitlements
+- `extension/safari/ChronicleSync/ChronicleSync Extension/Info.plist` - Extension info
+- `extension/safari/ChronicleSync/ChronicleSync/Info.plist` - App info
+
+### Swift Source Files
+- `extension/safari/ChronicleSync/ChronicleSync/AppDelegate.swift` - App delegate
+- `extension/safari/ChronicleSync/ChronicleSync/SceneDelegate.swift` - Scene delegate
+- `extension/safari/ChronicleSync/ChronicleSync/ViewController.swift` - Main view controller
+- `extension/safari/ChronicleSync/ChronicleSync Extension/SafariWebExtensionHandler.swift` - Extension handler
+
+## Modified Files
+
+The following existing files were modified in the `add-safari-extension` branch:
+
+### Package Configuration
+- `extension/package.json` - Added `build:safari` script
+
+### CI/CD Configuration
+- `.github/workflows/ci-cd-combined.yml` - Added Safari extension build steps
+
+## Functional Differences
+
+### New Capabilities
+- Support for Safari on macOS and iOS
+- Native app wrapper for the extension
+- Integration with Apple's extension ecosystem
+
+### Build Process Changes
+- Additional build step for Safari extension
+- Xcode build process for native app
+- Code signing requirements for Apple platforms
+
+### Development Workflow Changes
+- Need to use Xcode for Safari extension development
+- Additional testing requirements for Safari
+- Need for Apple Developer account for signing
+
+## Technical Implementation Details
+
+### Extension Architecture
+- Uses Safari Web Extension framework
+- Same core functionality as Chrome/Firefox extensions
+- Wrapped in a native macOS/iOS app
+
+### Platform-Specific Considerations
+- Safari has stricter security model
+- Some Chrome APIs may not be available or work differently
+- Need to handle Safari-specific permissions
+
+### Distribution Method
+- Chrome/Firefox: Web Store distribution
+- Safari: App Store distribution (requires App Store review)
+
+## Migration Considerations
+
+When working with the Safari extension:
+
+1. Always build the extension files first (`npm run build`)
+2. Use Xcode for building and testing the Safari extension
+3. Be aware of Safari-specific limitations and differences
+4. Test on both macOS and iOS if targeting both platforms
+5. Consider the App Store review guidelines for distribution

--- a/safari-extension-setup-guide.md
+++ b/safari-extension-setup-guide.md
@@ -1,0 +1,110 @@
+# ChronicleSync Safari Extension Setup Guide
+
+This guide will help you set up and run the ChronicleSync Safari extension on your local macOS machine using the `add-safari-extension` branch.
+
+## Prerequisites
+
+- macOS with Xcode 13 or later installed
+- Apple Developer account (for signing the extension)
+- Node.js and npm installed
+
+## Step 1: Clone and Prepare the Repository
+
+If you haven't already, clone the repository and checkout the `add-safari-extension` branch:
+
+```bash
+git clone https://github.com/posix4e/chroniclesync.git
+cd chroniclesync
+git checkout add-safari-extension
+```
+
+## Step 2: Build the Extension Files
+
+Navigate to the extension directory and install dependencies:
+
+```bash
+cd extension
+npm install
+npm run build
+```
+
+This will compile the TypeScript files and build the extension using Vite.
+
+## Step 3: Open the Xcode Project
+
+Open the Safari extension Xcode project:
+
+```bash
+open safari/ChronicleSync/ChronicleSync.xcodeproj
+```
+
+## Step 4: Configure Signing in Xcode
+
+1. In Xcode, select the "ChronicleSync" project in the Project Navigator (left sidebar)
+2. Select the "ChronicleSync" target
+3. Go to the "Signing & Capabilities" tab
+4. Select your Apple Developer Team from the dropdown
+5. Repeat this process for the "ChronicleSync Extension" target
+
+If you encounter any signing issues:
+- Ensure your Apple Developer account is active
+- Try using "Automatically manage signing" option
+- Check that the Bundle Identifier is unique (you may need to modify it)
+
+## Step 5: Build and Run the Extension
+
+1. Select the "ChronicleSync" scheme from the scheme selector in the toolbar
+2. Select your Mac as the run destination
+3. Click the Run button (▶️) or press Cmd+R
+
+This will build and launch the ChronicleSync app on your Mac.
+
+## Step 6: Enable the Extension in Safari
+
+1. After the app launches, click the "Enable Extension" button in the app
+2. This will open Safari's Extension preferences
+3. Check the box next to "ChronicleSync" to enable the extension
+4. The extension should now be active in Safari
+
+## Troubleshooting
+
+### If the extension doesn't appear in Safari:
+
+1. Open Safari
+2. Go to Safari > Settings > Extensions
+3. Verify that ChronicleSync is listed and enabled
+
+### If you encounter build errors:
+
+1. Check Xcode's Issue Navigator (Cmd+5) for specific error details
+2. Ensure all extension files were properly built in Step 2
+3. Try cleaning the build folder (Shift+Cmd+K) and rebuilding
+
+### If you encounter signing issues:
+
+1. Verify your Apple Developer account is active
+2. Try using a different Bundle Identifier
+3. Check that you have the necessary provisioning profiles
+
+## Differences from Main Branch
+
+The `add-safari-extension` branch adds the following components:
+
+1. Safari extension Xcode project structure
+2. Safari-specific extension implementation files
+3. Build script for Safari extension (`scripts/build-safari-extension.sh`)
+4. Additional npm script (`build:safari`) in package.json
+
+## Development Workflow
+
+For ongoing development:
+
+1. Make changes to the extension source files
+2. Run `npm run build` to rebuild the extension files
+3. In Xcode, build and run the app again to test your changes
+
+## Notes
+
+- The Safari extension uses the same core functionality as the Chrome/Firefox extensions
+- Safari Web Extensions have some limitations compared to Chrome extensions
+- You'll need to rebuild and reinstall the app when making changes to the extension

--- a/safari-extension-troubleshooting.md
+++ b/safari-extension-troubleshooting.md
@@ -1,0 +1,126 @@
+# ChronicleSync Safari Extension Troubleshooting Guide
+
+This guide addresses common issues you might encounter when setting up and running the ChronicleSync Safari extension.
+
+## Common Build Issues
+
+### 1. Code Signing Issues
+
+**Symptoms:**
+- "Code Sign Error" in Xcode
+- "No signing certificate" errors
+- "Failed to code sign" messages
+
+**Solutions:**
+- Ensure you have an active Apple Developer account
+- In Xcode, go to Preferences > Accounts and verify your Apple ID is added
+- Try using "Automatically manage signing" in the Signing & Capabilities tab
+- Create a new App ID in the Apple Developer portal if needed
+- Try using a different Bundle Identifier (e.g., add your initials to the existing one)
+
+### 2. Missing Files or Resources
+
+**Symptoms:**
+- "File not found" errors during build
+- Extension doesn't load properly in Safari
+- Missing functionality in the extension
+
+**Solutions:**
+- Ensure you've run `npm run build` before opening Xcode
+- Check that all files were copied to the Resources directory
+- Manually copy any missing files from the `dist` directory to `ChronicleSync Extension/Resources/`
+- Clean the build folder in Xcode (Shift+Cmd+K) and rebuild
+
+### 3. Entitlements Issues
+
+**Symptoms:**
+- App crashes on launch
+- Extension doesn't appear in Safari
+- Permission-related errors
+
+**Solutions:**
+- Check the entitlements file (`ChronicleSync_Extension.entitlements`)
+- Ensure the App Groups and other entitlements match your provisioning profile
+- Try removing custom entitlements temporarily for testing
+
+## Safari Extension Specific Issues
+
+### 1. Extension Not Appearing in Safari
+
+**Symptoms:**
+- Extension doesn't show up in Safari's Extensions preferences
+- Can't enable the extension
+
+**Solutions:**
+- Make sure you've launched the app at least once
+- Check Safari > Settings > Extensions to see if it's listed
+- Try restarting Safari
+- Verify the extension's Info.plist has the correct bundle identifier
+- Check Console.app for any extension-related errors
+
+### 2. Extension Not Working Properly
+
+**Symptoms:**
+- Extension is enabled but doesn't function
+- Features work differently than in Chrome/Firefox
+
+**Solutions:**
+- Check Safari's Web Inspector for JavaScript errors
+- Verify permissions are granted in Safari's Extension preferences
+- Remember that Safari Web Extensions have some limitations compared to Chrome
+- Check that the manifest.json is properly configured
+
+### 3. Debugging Issues
+
+**Symptoms:**
+- Can't debug the extension
+- Breakpoints not working
+- Console logs not appearing
+
+**Solutions:**
+- Enable the Develop menu in Safari (Safari > Settings > Advanced)
+- Use Safari's Web Inspector to debug (Develop > [Your Mac] > Extension Background Page)
+- Add explicit console.log statements for debugging
+- Check the system console (Console.app) for extension-related logs
+
+## macOS Specific Issues
+
+### 1. App Notarization Issues
+
+**Symptoms:**
+- "App is damaged and can't be opened" message
+- Gatekeeper blocking the app
+
+**Solutions:**
+- For development, you can right-click the app and select Open to bypass Gatekeeper
+- For distribution, you'll need to notarize the app with Apple
+- Use `xcodebuild` with the `-allowProvisioningUpdates` flag
+
+### 2. App Sandbox Issues
+
+**Symptoms:**
+- App crashes when accessing certain resources
+- Permission-related errors
+
+**Solutions:**
+- Check the app's entitlements and ensure they include necessary permissions
+- Add appropriate usage description strings in Info.plist
+- Test with reduced sandbox restrictions during development
+
+## Comparing with Chrome Extension
+
+If the Safari extension behaves differently than the Chrome version:
+
+1. Check for Safari-specific API limitations
+2. Verify that all content scripts are properly loaded
+3. Test with the same data in both browsers
+4. Look for browser detection code that might be affecting behavior
+
+## Getting Additional Help
+
+If you continue to experience issues:
+
+1. Check the Safari Web Extensions documentation: https://developer.apple.com/documentation/safariservices/safari_web_extensions
+2. Look for similar issues in the repository's issue tracker
+3. Provide detailed error messages and logs when seeking help
+4. Try with a clean Safari profile (create a new macOS user account for testing)

--- a/setup-safari-extension.sh
+++ b/setup-safari-extension.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Setup script for ChronicleSync Safari Extension
+set -e
+
+# Print header
+echo "===== ChronicleSync Safari Extension Setup ====="
+echo "This script will help you set up the Safari extension on your macOS machine."
+echo
+
+# Check if running on macOS
+if [ "$(uname)" != "Darwin" ]; then
+    echo "Error: This script must be run on macOS."
+    exit 1
+fi
+
+# Check if Xcode is installed
+if ! command -v xcodebuild &> /dev/null; then
+    echo "Error: Xcode is not installed. Please install Xcode from the App Store."
+    exit 1
+fi
+
+# Check if Node.js is installed
+if ! command -v node &> /dev/null; then
+    echo "Error: Node.js is not installed. Please install Node.js from https://nodejs.org/"
+    exit 1
+fi
+
+# Check if npm is installed
+if ! command -v npm &> /dev/null; then
+    echo "Error: npm is not installed. Please install npm (usually comes with Node.js)."
+    exit 1
+fi
+
+# Print environment information
+echo "Environment Information:"
+echo "macOS Version: $(sw_vers -productVersion)"
+echo "Xcode Version: $(xcodebuild -version | head -n 1)"
+echo "Node Version: $(node -v)"
+echo "npm Version: $(npm -v)"
+echo
+
+# Ensure we're in the right directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Check if we're on the right branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "add-safari-extension" ]; then
+    echo "Currently on branch: $CURRENT_BRANCH"
+    read -p "Would you like to switch to the add-safari-extension branch? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git checkout add-safari-extension
+        echo "Switched to add-safari-extension branch."
+    else
+        echo "Continuing with current branch: $CURRENT_BRANCH"
+    fi
+else
+    echo "Already on add-safari-extension branch."
+fi
+
+# Build the extension
+echo
+echo "Building the extension..."
+cd extension
+npm install
+npm run build
+
+# Open the Xcode project
+echo
+echo "Opening Xcode project..."
+open safari/ChronicleSync/ChronicleSync.xcodeproj
+
+# Print next steps
+echo
+echo "===== Next Steps ====="
+echo "1. In Xcode, select the ChronicleSync project in the Project Navigator"
+echo "2. Go to the Signing & Capabilities tab"
+echo "3. Select your Apple Developer Team for both targets"
+echo "4. Click the Run button to build and run the app"
+echo "5. In the app, click 'Enable Extension' to enable it in Safari"
+echo
+echo "For more detailed instructions, see safari-extension-setup-guide.md"
+echo "===== Setup Complete ====="


### PR DESCRIPTION
This PR adds comprehensive documentation and setup scripts for the Safari extension branch.

## Added Files

- `safari-extension-setup-guide.md`: Step-by-step guide for setting up the Safari extension
- `setup-safari-extension.sh`: Executable script to automate the setup process
- `safari-extension-troubleshooting.md`: Guide for troubleshooting common Safari extension issues
- `safari-extension-branch-comparison.md`: Detailed comparison between main and add-safari-extension branches

## Purpose

These documents and scripts will help users get the Safari extension working on their local macOS machines by providing clear instructions, automation, and troubleshooting guidance.