### PR TITLE
Update GitHub Actions to only trigger pages workflow when pages directory changes

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -3,8 +3,14 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main]
+    paths:
+      - 'pages/**'
+      - '.github/workflows/ci-cd-combined.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'pages/**'
+      - '.github/workflows/ci-cd-combined.yml'
   workflow_dispatch:
     inputs:
       browser:
@@ -31,7 +37,47 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      pages_changed: ${{ steps.filter.outputs.pages_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check for changes in pages directory
+        id: filter
+        run: |
+          # For workflow_dispatch, always consider pages as changed
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "pages_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # For push and pull_request events, check if pages directory was modified
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            BASE_SHA=$(git rev-parse HEAD~1)
+            HEAD_SHA=${{ github.sha }}
+          else
+            BASE_SHA=${{ github.event.pull_request.base.sha }}
+            HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          fi
+          
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+          if echo "$CHANGED_FILES" | grep -q "^pages/"; then
+            echo "pages_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "pages_changed=false" >> $GITHUB_OUTPUT
+          fi
+          
+          # Debug output
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
   build-and-test:
+    needs: check-changes
+    if: needs.check-changes.outputs.pages_changed == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     outputs:
@@ -53,6 +99,7 @@ jobs:
         env:
           API_URL: ${{ github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz' }}
         run: |
+          echo "Running Pages tests because changes were detected in the pages directory"
           npm ci
           npm run lint
           npm run test
@@ -104,6 +151,7 @@ jobs:
           PWDEBUG: ${{ github.event.inputs.debug && '1' || '' }}
           PORT: 3000
         run: |
+          echo "Running Playwright tests for pages because changes were detected in the pages directory"
           npm ci
           npx playwright install --with-deps
           # Run tests in headless mode for all browsers if no specific browser is selected
@@ -130,7 +178,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --branch main --commit-dirty=true; else npm run deploy -- --branch ${{ github.head_ref }} --commit-dirty=true; fi
+        run: |
+          echo "Deploying Pages because changes were detected in the pages directory"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then 
+            npm run deploy -- --branch main --commit-dirty=true
+          else 
+            npm run deploy -- --branch ${{ github.head_ref }} --commit-dirty=true
+          fi
 
       - name: Deploy Worker
         id: deploy-worker
@@ -149,8 +203,8 @@ jobs:
           fi
 
   playwright-extension-tests:
-    needs: build-and-test
-    if: success()
+    needs: [check-changes, build-and-test]
+    if: needs.check-changes.outputs.pages_changed == 'true' && success()
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ chroniclesync/
 ├── extension/      # Chrome extension
 └── worker/         # Cloudflare Worker backend
 ```
+
+### CI/CD Pipeline
+
+The project uses GitHub Actions for continuous integration and deployment:
+
+- **Path-Based Triggers**: The CI/CD pipeline for pages is only triggered when changes are made to the `pages/` directory
+- **Manual Workflow**: You can also manually trigger the workflow using the GitHub Actions UI
+- **Deployment**: Pages are automatically deployed to Cloudflare Pages when changes are detected in the pages directory
+
+To modify the CI/CD pipeline configuration, see the workflow file at `.github/workflows/ci-cd-combined.yml`.

--- a/pages/DEVELOPER.md
+++ b/pages/DEVELOPER.md
@@ -95,6 +95,29 @@ The web application implements real-time synchronization with:
    npm run deploy
    ```
 
+### CI/CD Pipeline
+
+The pages application uses a GitHub Actions workflow for continuous integration and deployment:
+
+1. **Automatic Triggers**: 
+   - The CI/CD pipeline is automatically triggered when changes are made to files in the `pages/` directory
+   - The workflow will not run for changes to other parts of the repository
+
+2. **Manual Deployment**:
+   - You can manually trigger the workflow from the GitHub Actions tab
+   - This is useful for deploying without making code changes
+
+3. **Workflow Steps**:
+   - Lint and test the pages code
+   - Build the application
+   - Run Playwright end-to-end tests
+   - Deploy to Cloudflare Pages (for main branch or PRs targeting main)
+
+4. **Environment Variables**:
+   - The workflow uses different API endpoints based on the branch:
+     - `https://api.chroniclesync.xyz` for the main branch
+     - `https://api-staging.chroniclesync.xyz` for other branches
+
 ## Performance Optimization
 
 1. **Code Splitting**

--- a/pages/DEVELOPER.md
+++ b/pages/DEVELOPER.md
@@ -95,29 +95,6 @@ The web application implements real-time synchronization with:
    npm run deploy
    ```
 
-### CI/CD Pipeline
-
-The pages application uses a GitHub Actions workflow for continuous integration and deployment:
-
-1. **Automatic Triggers**: 
-   - The CI/CD pipeline is automatically triggered when changes are made to files in the `pages/` directory
-   - The workflow will not run for changes to other parts of the repository
-
-2. **Manual Deployment**:
-   - You can manually trigger the workflow from the GitHub Actions tab
-   - This is useful for deploying without making code changes
-
-3. **Workflow Steps**:
-   - Lint and test the pages code
-   - Build the application
-   - Run Playwright end-to-end tests
-   - Deploy to Cloudflare Pages (for main branch or PRs targeting main)
-
-4. **Environment Variables**:
-   - The workflow uses different API endpoints based on the branch:
-     - `https://api.chroniclesync.xyz` for the main branch
-     - `https://api-staging.chroniclesync.xyz` for other branches
-
 ## Performance Optimization
 
 1. **Code Splitting**


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to only trigger the build/test/deploy pipeline for the pages directory when files in that directory are modified.

### Changes:

1. Added path filters to the workflow triggers to only run when files in the `pages/` directory are changed
2. Added a new `check-changes` job that determines if the pages directory was modified
3. Updated all jobs to depend on the `check-changes` job and only run when pages have changed
4. Added clear logging to indicate when jobs are running due to pages directory changes
5. Updated documentation in README.md to explain the CI/CD pipeline behavior

This change will improve CI/CD efficiency by avoiding unnecessary builds and deployments when only non-pages files are modified.