### PR TITLE
Optimize GitHub Pages workflow

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -3,8 +3,12 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'pages/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'pages/**'
   workflow_dispatch:
     inputs:
       browser:
@@ -48,15 +52,7 @@ jobs:
             extension/package-lock.json
             worker/package-lock.json
 
-      - name: Test Pages
-        working-directory: pages
-        env:
-          API_URL: ${{ github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz' }}
-        run: |
-          npm ci
-          npm run lint
-          npm run test
-          npm run build
+
 
       - name: Build Extension
         working-directory: extension
@@ -96,41 +92,7 @@ jobs:
         working-directory: worker
         run: npm ci && npm run lint && npm run test:coverage
 
-      - name: Install dependencies and run page tests
-        working-directory: pages
-        env:
-          API_URL: ${{ github.event.inputs.api_endpoint || (github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz') }}
-          DEBUG: ${{ github.event.inputs.debug && 'pw:api' || '' }}
-          PWDEBUG: ${{ github.event.inputs.debug && '1' || '' }}
-          PORT: 3000
-        run: |
-          npm ci
-          npx playwright install --with-deps
-          # Run tests in headless mode for all browsers if no specific browser is selected
-          if [ -z "${{ github.event.inputs.browser }}" ]; then
-            xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
-              npx playwright test
-          else
-            xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
-              npx playwright test --project=${{ github.event.inputs.browser }}
-          fi
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-reports-pages
-          path: |
-            pages/playwright-report/
-            pages/test-results/
-          retention-days: 30
 
-      - name: Deploy Pages
-        if: (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') && success()
-        working-directory: pages
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --branch main --commit-dirty=true; else npm run deploy -- --branch ${{ github.head_ref }} --commit-dirty=true; fi
 
       - name: Deploy Worker
         id: deploy-worker

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,95 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pages/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pages/**'
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: 'Browser to test (leave empty to test all browsers)'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - chromium
+          - firefox
+      api_endpoint:
+        description: 'API endpoint to test against'
+        required: false
+        type: string
+        default: 'https://api-staging.chroniclesync.xyz'
+      debug:
+        description: 'Enable debug mode'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build-and-deploy-pages:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: pages/package-lock.json
+
+      - name: Test Pages
+        working-directory: pages
+        env:
+          API_URL: ${{ github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz' }}
+        run: |
+          npm ci
+          npm run lint
+          npm run test
+          npm run build
+
+      - name: Run page tests
+        working-directory: pages
+        env:
+          API_URL: ${{ github.event.inputs.api_endpoint || (github.ref == 'refs/heads/main' && 'https://api.chroniclesync.xyz' || 'https://api-staging.chroniclesync.xyz') }}
+          DEBUG: ${{ github.event.inputs.debug && 'pw:api' || '' }}
+          PWDEBUG: ${{ github.event.inputs.debug && '1' || '' }}
+          PORT: 3000
+        run: |
+          npm ci
+          npx playwright install --with-deps
+          # Run tests in headless mode for all browsers if no specific browser is selected
+          if [ -z "${{ github.event.inputs.browser }}" ]; then
+            xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
+              npx playwright test
+          else
+            xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
+              npx playwright test --project=${{ github.event.inputs.browser }}
+          fi
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-reports-pages
+          path: |
+            pages/playwright-report/
+            pages/test-results/
+          retention-days: 30
+
+      - name: Deploy Pages
+        if: (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') && success()
+        working-directory: pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: if [ "${{ github.ref }}" = "refs/heads/main" ]; then npm run deploy -- --branch main --commit-dirty=true; else npm run deploy -- --branch ${{ github.head_ref }} --commit-dirty=true; fi


### PR DESCRIPTION
This PR optimizes the GitHub Actions workflow to only run GitHub Pages related steps when files in the pages directory change.

**Changes:**

1. Created a separate `pages.yml` workflow file that only triggers when files in the pages directory change
2. Modified the original `ci-cd-combined.yml` workflow to ignore changes in the pages directory
3. Removed GitHub Pages related steps from the original workflow

This approach uses GitHub Actions built-in path filtering capabilities for efficient workflow execution.