### PR TITLE
Fix Safari extension signing and add documentation guides

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -242,8 +242,15 @@ jobs:
           # Create directory for provisioning profiles if it doesn't exist
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           
-          # Copy provisioning profile to directory
-          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          # Extract profile UUID for unique filename
+          PROFILE_UUID=$(grep -a -A 1 "UUID" $PROFILE_PATH | grep -o "[-A-Z0-9]\{36\}" || echo "profile")
+          
+          # Copy provisioning profile to directory with unique name
+          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
+          
+          # Debug: List installed provisioning profiles
+          echo "Installed provisioning profiles:"
+          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
 
       - name: Prepare Safari Extension
         run: |
@@ -306,11 +313,11 @@ jobs:
           </plist>
           EOL
           
-          # Build and sign the app
-          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
+          # Build and sign the app with allowProvisioningUpdates flag
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" -allowProvisioningUpdates
           
-          # Export the archive as IPA
-          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
+          # Export the archive as IPA with allowProvisioningUpdates flag
+          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" -allowProvisioningUpdates
 
       - name: Test Safari Extension
         env:

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -229,46 +229,26 @@ jobs:
           security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
           
-      - name: Install the provisioning profiles
+      - name: Install the provisioning profile
         env:
-          APP_PROVISIONING_PROFILE: ${{ secrets.APPLE_APP_PROVISIONING_PROFILE }}
-          EXTENSION_PROVISIONING_PROFILE: ${{ secrets.APPLE_EXTENSION_PROVISIONING_PROFILE }}
           PROVISIONING_PROFILE_CONTENT: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
         run: |
           # Create directory for provisioning profiles if it doesn't exist
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           
-          # Import app provisioning profile from secrets
-          if [ ! -z "$APP_PROVISIONING_PROFILE" ]; then
-            APP_PROFILE_PATH=$RUNNER_TEMP/app_profile.mobileprovision
-            echo -n "$APP_PROVISIONING_PROFILE" | base64 --decode -o $APP_PROFILE_PATH
-            
-            # Copy app provisioning profile with specific name
-            cp $APP_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Profile.mobileprovision
-            echo "Installed app provisioning profile"
-          else
-            echo "WARNING: APP_PROVISIONING_PROFILE is not set"
-          fi
+          # Import provisioning profile from secrets
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          echo -n "$PROVISIONING_PROFILE_CONTENT" | base64 --decode -o $PROFILE_PATH
           
-          # Import extension provisioning profile from secrets
-          if [ ! -z "$EXTENSION_PROVISIONING_PROFILE" ]; then
-            EXT_PROFILE_PATH=$RUNNER_TEMP/extension_profile.mobileprovision
-            echo -n "$EXTENSION_PROVISIONING_PROFILE" | base64 --decode -o $EXT_PROFILE_PATH
-            
-            # Copy extension provisioning profile with specific name
-            cp $EXT_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Extension_Profile.mobileprovision
-            echo "Installed extension provisioning profile"
-          else
-            echo "WARNING: EXTENSION_PROVISIONING_PROFILE is not set"
-          fi
+          # Extract profile UUID for unique filename
+          PROFILE_UUID=$(grep -a -A 1 "UUID" $PROFILE_PATH | grep -o "[-A-Z0-9]\{36\}" || echo "profile")
           
-          # For backward compatibility
-          if [ ! -z "$PROVISIONING_PROFILE_CONTENT" ]; then
-            PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
-            echo -n "$PROVISIONING_PROFILE_CONTENT" | base64 --decode -o $PROFILE_PATH
-            cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Profile.mobileprovision
-            echo "Installed legacy provisioning profile"
-          fi
+          # Copy provisioning profile to directory with UUID as filename
+          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
+          
+          # Also create symbolic links with the names expected by the build script
+          ln -sf ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Profile.mobileprovision
+          ln -sf ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Extension_Profile.mobileprovision
           
           # Debug: List installed provisioning profiles
           echo "Installed provisioning profiles:"
@@ -333,9 +313,9 @@ jobs:
               <string>manual</string>
               <key>provisioningProfiles</key>
               <dict>
-                  <key>${APPLE_APP_ID}</key>
+                  <key>com.chroniclesync.ChronicleSync</key>
                   <string>ChronicleSync_Profile</string>
-                  <key>${APPLE_APP_ID}.extension</key>
+                  <key>com.chroniclesync.ChronicleSync.Extension</key>
                   <string>ChronicleSync_Extension_Profile</string>
               </dict>
           </dict>
@@ -345,15 +325,14 @@ jobs:
           # Build and sign the app with manual signing
           xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive \
             DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
-            PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" \
             CODE_SIGN_STYLE="Manual" \
             CODE_SIGN_IDENTITY="iPhone Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="ChronicleSync_Profile"
+            "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][config=Release][bundle=com.chroniclesync.ChronicleSync]"="ChronicleSync_Profile" \
+            "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][config=Release][bundle=com.chroniclesync.ChronicleSync.Extension]"="ChronicleSync_Extension_Profile"
           
           # Export the archive as IPA
           xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" \
-            DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
-            PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
+            DEVELOPMENT_TEAM="${APPLE_TEAM_ID}"
 
       - name: Test Safari Extension
         env:

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -206,6 +206,44 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+          
+      - name: Install the Apple certificate
+        env:
+          CERTIFICATE_CONTENT: ${{ secrets.APPLE_CERTIFICATE_CONTENT }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          
+          # Import certificate from secrets
+          echo -n "$CERTIFICATE_CONTENT" | base64 --decode -o $CERTIFICATE_PATH
+          
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          
+      - name: Install the provisioning profile
+        env:
+          PROVISIONING_PROFILE_CONTENT: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
+        run: |
+          # Create variables
+          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          
+          # Import provisioning profile from secrets
+          echo -n "$PROVISIONING_PROFILE_CONTENT" | base64 --decode -o $PROFILE_PATH
+          
+          # Create directory for provisioning profiles if it doesn't exist
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          
+          # Copy provisioning profile to directory
+          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
       - name: Prepare Safari Extension
         run: |
@@ -240,12 +278,43 @@ jobs:
           fi
 
       - name: Build Safari Extension
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
         run: |
           cd safari-extension
-          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+          
+          # Create a temporary exportOptions.plist with the correct team ID
+          cat > exportOptions.plist << EOL
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>teamID</key>
+    <string>${APPLE_TEAM_ID}</string>
+    <key>compileBitcode</key>
+    <false/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>signingStyle</key>
+    <string>automatic</string>
+</dict>
+</plist>
+EOL
+          
+          # Build and sign the app
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
+          
+          # Export the archive as IPA
+          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
 
       - name: Test Safari Extension
+        env:
+          APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
         run: |
           cd safari-extension
           # Start simulator
@@ -256,7 +325,7 @@ jobs:
           xcrun simctl install "$DEVICE_ID" "build/ChronicleSync.app"
           
           # Launch app
-          xcrun simctl launch "$DEVICE_ID" "com.chroniclesync.ChronicleSync"
+          xcrun simctl launch "$DEVICE_ID" "${APPLE_APP_ID}"
           
           # Wait for app to fully launch
           sleep 5

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -229,24 +229,46 @@ jobs:
           security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
           
-      - name: Install the provisioning profile
+      - name: Install the provisioning profiles
         env:
+          APP_PROVISIONING_PROFILE: ${{ secrets.APPLE_APP_PROVISIONING_PROFILE }}
+          EXTENSION_PROVISIONING_PROFILE: ${{ secrets.APPLE_EXTENSION_PROVISIONING_PROFILE }}
           PROVISIONING_PROFILE_CONTENT: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
         run: |
-          # Create variables
-          PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
-          
-          # Import provisioning profile from secrets
-          echo -n "$PROVISIONING_PROFILE_CONTENT" | base64 --decode -o $PROFILE_PATH
-          
           # Create directory for provisioning profiles if it doesn't exist
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           
-          # Extract profile UUID for unique filename
-          PROFILE_UUID=$(grep -a -A 1 "UUID" $PROFILE_PATH | grep -o "[-A-Z0-9]\{36\}" || echo "profile")
+          # Import app provisioning profile from secrets
+          if [ ! -z "$APP_PROVISIONING_PROFILE" ]; then
+            APP_PROFILE_PATH=$RUNNER_TEMP/app_profile.mobileprovision
+            echo -n "$APP_PROVISIONING_PROFILE" | base64 --decode -o $APP_PROFILE_PATH
+            
+            # Copy app provisioning profile with specific name
+            cp $APP_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Profile.mobileprovision
+            echo "Installed app provisioning profile"
+          else
+            echo "WARNING: APP_PROVISIONING_PROFILE is not set"
+          fi
           
-          # Copy provisioning profile to directory with unique name
-          cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
+          # Import extension provisioning profile from secrets
+          if [ ! -z "$EXTENSION_PROVISIONING_PROFILE" ]; then
+            EXT_PROFILE_PATH=$RUNNER_TEMP/extension_profile.mobileprovision
+            echo -n "$EXTENSION_PROVISIONING_PROFILE" | base64 --decode -o $EXT_PROFILE_PATH
+            
+            # Copy extension provisioning profile with specific name
+            cp $EXT_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Extension_Profile.mobileprovision
+            echo "Installed extension provisioning profile"
+          else
+            echo "WARNING: EXTENSION_PROVISIONING_PROFILE is not set"
+          fi
+          
+          # For backward compatibility
+          if [ ! -z "$PROVISIONING_PROFILE_CONTENT" ]; then
+            PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+            echo -n "$PROVISIONING_PROFILE_CONTENT" | base64 --decode -o $PROFILE_PATH
+            cp $PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/ChronicleSync_Profile.mobileprovision
+            echo "Installed legacy provisioning profile"
+          fi
           
           # Debug: List installed provisioning profiles
           echo "Installed provisioning profiles:"
@@ -291,7 +313,7 @@ jobs:
         run: |
           cd safari-extension
           
-          # Create a temporary exportOptions.plist with the correct team ID
+          # Create a temporary exportOptions.plist with the correct team ID and manual signing
           cat > exportOptions.plist << EOL
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -308,16 +330,30 @@ jobs:
               <key>uploadSymbols</key>
               <true/>
               <key>signingStyle</key>
-              <string>automatic</string>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>${APPLE_APP_ID}</key>
+                  <string>ChronicleSync_Profile</string>
+                  <key>${APPLE_APP_ID}.extension</key>
+                  <string>ChronicleSync_Extension_Profile</string>
+              </dict>
           </dict>
           </plist>
           EOL
           
-          # Build and sign the app with allowProvisioningUpdates flag
-          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" -allowProvisioningUpdates
+          # Build and sign the app with manual signing
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive \
+            DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" \
+            CODE_SIGN_STYLE="Manual" \
+            CODE_SIGN_IDENTITY="iPhone Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="ChronicleSync_Profile"
           
-          # Export the archive as IPA with allowProvisioningUpdates flag
-          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" -allowProvisioningUpdates
+          # Export the archive as IPA
+          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" \
+            DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"
 
       - name: Test Safari Extension
         env:

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -286,25 +286,25 @@ jobs:
           
           # Create a temporary exportOptions.plist with the correct team ID
           cat > exportOptions.plist << EOL
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>method</key>
-    <string>development</string>
-    <key>teamID</key>
-    <string>${APPLE_TEAM_ID}</string>
-    <key>compileBitcode</key>
-    <false/>
-    <key>uploadBitcode</key>
-    <false/>
-    <key>uploadSymbols</key>
-    <true/>
-    <key>signingStyle</key>
-    <string>automatic</string>
-</dict>
-</plist>
-EOL
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>development</string>
+              <key>teamID</key>
+              <string>${APPLE_TEAM_ID}</string>
+              <key>compileBitcode</key>
+              <false/>
+              <key>uploadBitcode</key>
+              <false/>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>signingStyle</key>
+              <string>automatic</string>
+          </dict>
+          </plist>
+          EOL
           
           # Build and sign the app
           xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}"

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -20,6 +20,7 @@ on:
           - ''
           - chromium
           - firefox
+          - safari
       api_endpoint:
         description: 'API endpoint to test against'
         required: false
@@ -180,3 +181,103 @@ jobs:
             extension/playwright-report/
             extension/test-results/${{ matrix.browser == 'chrome' && 'chrome' || 'firefox' }}/
           retention-days: 30
+
+  build-safari-extension:
+    needs: build-and-test
+    if: success() && (github.event.inputs.browser == '' || github.event.inputs.browser == 'safari')
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            extension/package-lock.json
+
+      - name: Download extension artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: chrome-extension
+          path: extension/dist
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Prepare Safari Extension
+        run: |
+          # Create necessary directories
+          mkdir -p "safari-extension/ChronicleSync Extension/Resources"
+          
+          # Copy extension files to Safari extension
+          cp extension/popup.html "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/popup.css "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/settings.html "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/settings.css "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/history.html "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/history.css "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/devtools.html "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/devtools.css "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/bip39-wordlist.js "safari-extension/ChronicleSync Extension/Resources/"
+          
+          # Extract and copy JS files from the Chrome extension
+          unzip -o extension/dist/chrome-extension.zip -d extension/dist/extracted
+          cp extension/dist/extracted/popup.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/background.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/settings.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/history.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/devtools.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/devtools-page.js "safari-extension/ChronicleSync Extension/Resources/"
+          cp extension/dist/extracted/content-script.js "safari-extension/ChronicleSync Extension/Resources/"
+          
+          # Copy assets directory if it exists
+          if [ -d "extension/dist/extracted/assets" ]; then
+            mkdir -p "safari-extension/ChronicleSync Extension/Resources/assets"
+            cp -R extension/dist/extracted/assets/* "safari-extension/ChronicleSync Extension/Resources/assets/"
+          fi
+
+      - name: Build Safari Extension
+        run: |
+          cd safari-extension
+          xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+          xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+      - name: Test Safari Extension
+        run: |
+          cd safari-extension
+          # Start simulator
+          DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone" | head -1 | sed -E 's/.*\(([A-Za-z0-9-]+)\).*/\1/')
+          xcrun simctl boot "$DEVICE_ID"
+          
+          # Install app
+          xcrun simctl install "$DEVICE_ID" "build/ChronicleSync.app"
+          
+          # Launch app
+          xcrun simctl launch "$DEVICE_ID" "com.chroniclesync.ChronicleSync"
+          
+          # Wait for app to fully launch
+          sleep 5
+          
+          # Take screenshot
+          mkdir -p screenshots
+          xcrun simctl io "$DEVICE_ID" screenshot "screenshots/chroniclesync_screenshot.png"
+          
+          # Shutdown simulator
+          xcrun simctl shutdown "$DEVICE_ID"
+
+      - name: Upload IPA Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: safari-extension-ipa
+          path: safari-extension/build/ChronicleSync.ipa
+          retention-days: 14
+          
+      - name: Upload Screenshot Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: safari-extension-screenshot
+          path: safari-extension/screenshots/chroniclesync_screenshot.png
+          retention-days: 14

--- a/safari-extension/ChronicleSync Extension/Info.plist
+++ b/safari-extension/ChronicleSync Extension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ChronicleSync Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/safari-extension/ChronicleSync Extension/Resources/manifest.json
+++ b/safari-extension/ChronicleSync Extension/Resources/manifest.json
@@ -1,0 +1,42 @@
+{
+  "manifest_version": 3,
+  "name": "ChronicleSync Extension",
+  "version": "1.0",
+  "description": "ChronicleSync Safari Extension",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs",
+    "history",
+    "storage",
+    "unlimitedStorage"
+  ],
+  "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.chroniclesync.xyz/*",
+    "https://api-staging.chroniclesync.xyz/*"
+  ],
+  "web_accessible_resources": [{
+    "resources": ["history.html"],
+    "matches": ["<all_urls>"]
+  }],
+  "browser_specific_settings": {
+    "safari": {
+      "strict_min_version": "14.0"
+    }
+  }
+}

--- a/safari-extension/ChronicleSync Extension/SafariWebExtensionHandler.swift
+++ b/safari-extension/ChronicleSync Extension/SafariWebExtensionHandler.swift
@@ -1,0 +1,17 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey]
+        os_log(.default, "Received message from browser.runtime.sendNativeMessage: %@", message as! CVarArg)
+
+        let response = NSExtensionItem()
+        response.userInfo = [ SFExtensionMessageKey: [ "Response to": message ] ]
+
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+
+}

--- a/safari-extension/ChronicleSync.xcodeproj/project.pbxproj
+++ b/safari-extension/ChronicleSync.xcodeproj/project.pbxproj
@@ -1,0 +1,620 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1A1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */; };
+		1A1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A28 /* background.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A29 /* background.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A2A /* content-script.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A2C /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2D /* popup.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A2E /* popup.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2F /* popup.html */; };
+		1A1A1A1A1A1A1A1A1A1A1A30 /* popup.css in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A31 /* popup.css */; };
+		1A1A1A1A1A1A1A1A1A1A1A32 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */; };
+		1A1A1A1A1A1A1A1A1A1A1A34 /* settings.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A35 /* settings.html */; };
+		1A1A1A1A1A1A1A1A1A1A1A36 /* settings.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A37 /* settings.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A38 /* settings.css in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A39 /* settings.css */; };
+		1A1A1A1A1A1A1A1A1A1A1A3A /* history.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A3B /* history.html */; };
+		1A1A1A1A1A1A1A1A1A1A1A3C /* history.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A3D /* history.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A3E /* history.css in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A3F /* history.css */; };
+		1A1A1A1A1A1A1A1A1A1A1A40 /* devtools.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A41 /* devtools.html */; };
+		1A1A1A1A1A1A1A1A1A1A1A42 /* devtools.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A43 /* devtools.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A44 /* devtools.css in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A45 /* devtools.css */; };
+		1A1A1A1A1A1A1A1A1A1A1A46 /* devtools-page.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A47 /* devtools-page.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A48 /* bip39-wordlist.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A49 /* bip39-wordlist.js */; };
+		1A1A1A1A1A1A1A1A1A1A1A4A /* ChronicleSync Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A4B /* ChronicleSync Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1A1A1A1A1A1A1A1A1A1A1A4C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A1A1A1A1A1A1A1A1A1A1A4D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A1A1A1A1A1A1A1A1A1A1A4E;
+			remoteInfo = "ChronicleSync Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A4F /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A4A /* ChronicleSync Extension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		1A1A1A1A1A1A1A1A1A1A1A50 /* ChronicleSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChronicleSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A51 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A52 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A4B /* ChronicleSync Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ChronicleSync Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A54 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebExtensionHandler.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A29 /* background.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = background.js; path = Resources/background.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "content-script.js"; path = "Resources/content-script.js"; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A2D /* popup.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = popup.js; path = Resources/popup.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A2F /* popup.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = popup.html; path = Resources/popup.html; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A31 /* popup.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = popup.css; path = Resources/popup.css; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = manifest.json; path = Resources/manifest.json; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A35 /* settings.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = settings.html; path = Resources/settings.html; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A37 /* settings.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = settings.js; path = Resources/settings.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A39 /* settings.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = settings.css; path = Resources/settings.css; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A3B /* history.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = history.html; path = Resources/history.html; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A3D /* history.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = history.js; path = Resources/history.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A3F /* history.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = history.css; path = Resources/history.css; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A41 /* devtools.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = devtools.html; path = Resources/devtools.html; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A43 /* devtools.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = devtools.js; path = Resources/devtools.js; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A45 /* devtools.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = devtools.css; path = Resources/devtools.css; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A47 /* devtools-page.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "devtools-page.js"; path = "Resources/devtools-page.js"; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A49 /* bip39-wordlist.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "bip39-wordlist.js"; path = "Resources/bip39-wordlist.js"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A55 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A56 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A1A1A1A1A1A1A1A1A1A1A57 = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A58 /* ChronicleSync */,
+				1A1A1A1A1A1A1A1A1A1A1A59 /* ChronicleSync Extension */,
+				1A1A1A1A1A1A1A1A1A1A1A5A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A5A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A50 /* ChronicleSync.app */,
+				1A1A1A1A1A1A1A1A1A1A4B /* ChronicleSync Extension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A58 /* ChronicleSync */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */,
+				1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */,
+				1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A53 /* Info.plist */,
+			);
+			path = ChronicleSync;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A59 /* ChronicleSync Extension */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */,
+				1A1A1A1A1A1A1A1A1A1A54 /* Info.plist */,
+				1A1A1A1A1A1A1A1A1A1A5B /* Resources */,
+			);
+			path = "ChronicleSync Extension";
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A5B /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A29 /* background.js */,
+				1A1A1A1A1A1A1A1A1A1A2B /* content-script.js */,
+				1A1A1A1A1A1A1A1A1A1A2D /* popup.js */,
+				1A1A1A1A1A1A1A1A1A1A2F /* popup.html */,
+				1A1A1A1A1A1A1A1A1A1A31 /* popup.css */,
+				1A1A1A1A1A1A1A1A1A1A33 /* manifest.json */,
+				1A1A1A1A1A1A1A1A1A1A35 /* settings.html */,
+				1A1A1A1A1A1A1A1A1A1A37 /* settings.js */,
+				1A1A1A1A1A1A1A1A1A1A39 /* settings.css */,
+				1A1A1A1A1A1A1A1A1A1A3B /* history.html */,
+				1A1A1A1A1A1A1A1A1A1A3D /* history.js */,
+				1A1A1A1A1A1A1A1A1A1A3F /* history.css */,
+				1A1A1A1A1A1A1A1A1A1A41 /* devtools.html */,
+				1A1A1A1A1A1A1A1A1A1A43 /* devtools.js */,
+				1A1A1A1A1A1A1A1A1A1A45 /* devtools.css */,
+				1A1A1A1A1A1A1A1A1A1A47 /* devtools-page.js */,
+				1A1A1A1A1A1A1A1A1A1A49 /* bip39-wordlist.js */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A1A1A1A1A1A1A1A1A1A1A5C /* ChronicleSync */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A5D /* Build configuration list for PBXNativeTarget "ChronicleSync" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A55 /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A5E /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A5F /* Resources */,
+				1A1A1A1A1A1A1A1A1A1A4F /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A1A1A1A1A1A1A1A1A1A1A60 /* PBXTargetDependency */,
+			);
+			name = ChronicleSync;
+			productName = ChronicleSync;
+			productReference = 1A1A1A1A1A1A1A1A1A1A50 /* ChronicleSync.app */;
+			productType = "com.apple.product-type.application";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4E /* ChronicleSync Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A61 /* Build configuration list for PBXNativeTarget "ChronicleSync Extension" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A56 /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A62 /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A63 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ChronicleSync Extension";
+			productName = "ChronicleSync Extension";
+			productReference = 1A1A1A1A1A1A1A1A1A1A4B /* ChronicleSync Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A1A1A1A1A1A1A1A1A1A1A4D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					1A1A1A1A1A1A1A1A1A1A1A5C = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					1A1A1A1A1A1A1A1A1A1A1A4E = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A64 /* Build configuration list for PBXProject "ChronicleSync" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A1A1A1A1A1A1A1A1A1A1A57;
+			productRefGroup = 1A1A1A1A1A1A1A1A1A1A1A5A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A1A1A1A1A1A1A1A1A1A1A5C /* ChronicleSync */,
+				1A1A1A1A1A1A1A1A1A1A1A4E /* ChronicleSync Extension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A5F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */,
+				1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */,
+				1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A63 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A48 /* bip39-wordlist.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A46 /* devtools-page.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A44 /* devtools.css in Resources */,
+				1A1A1A1A1A1A1A1A1A1A42 /* devtools.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A40 /* devtools.html in Resources */,
+				1A1A1A1A1A1A1A1A1A1A3E /* history.css in Resources */,
+				1A1A1A1A1A1A1A1A1A1A3C /* history.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A3A /* history.html in Resources */,
+				1A1A1A1A1A1A1A1A1A1A38 /* settings.css in Resources */,
+				1A1A1A1A1A1A1A1A1A1A36 /* settings.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A34 /* settings.html in Resources */,
+				1A1A1A1A1A1A1A1A1A1A32 /* manifest.json in Resources */,
+				1A1A1A1A1A1A1A1A1A1A30 /* popup.css in Resources */,
+				1A1A1A1A1A1A1A1A1A1A2E /* popup.html in Resources */,
+				1A1A1A1A1A1A1A1A1A1A2C /* popup.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A2A /* content-script.js in Resources */,
+				1A1A1A1A1A1A1A1A1A1A28 /* background.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A5E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A1A1A1A1A1A1A1A1A1A1A60 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A1A1A1A1A1A1A1A1A1A1A4E /* ChronicleSync Extension */;
+			targetProxy = 1A1A1A1A1A1A1A1A1A1A4C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A51 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A52 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		1A1A1A1A1A1A1A1A1A1A1A65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A66 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A67 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.chroniclesync.ChronicleSync.Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.chroniclesync.ChronicleSync.Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A69 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChronicleSync;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.chroniclesync.ChronicleSync";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A6A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ChronicleSync;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.chroniclesync.ChronicleSync";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A1A1A1A1A1A1A1A1A1A1A64 /* Build configuration list for PBXProject "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A65 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A66 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A61 /* Build configuration list for PBXNativeTarget "ChronicleSync Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A67 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A5D /* Build configuration list for PBXNativeTarget "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A69 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A6A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A1A1A1A1A1A1A1A1A1A1A4D /* Project object */;
+}

--- a/safari-extension/ChronicleSync/AppDelegate.swift
+++ b/safari-extension/ChronicleSync/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}

--- a/safari-extension/ChronicleSync/Base.lproj/LaunchScreen.storyboard
+++ b/safari-extension/ChronicleSync/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dGt-Ve-8bG">
+                                <rect key="frame" x="20" y="408" width="353" height="36"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="dGt-Ve-8bG" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Jgc-Nh-gRE"/>
+                            <constraint firstItem="dGt-Ve-8bG" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Jgc-Nh-gRF"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dGt-Ve-8bG" secondAttribute="trailing" constant="20" id="Jgc-Nh-gRG"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/safari-extension/ChronicleSync/Base.lproj/Main.storyboard
+++ b/safari-extension/ChronicleSync/Base.lproj/Main.storyboard
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ChronicleSync" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dGt-Ve-8bF">
+                                <rect key="frame" x="96.666666666666686" y="408.66666666666669" width="200" height="35"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Ygc-Nh-gRB"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Enable Safari Extension"/>
+                                <connections>
+                                    <action selector="openSafariExtensionPreferences:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Jgc-Nh-gRB"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dGt-Ve-8bG">
+                                <rect key="frame" x="20" y="159" width="353" height="36"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To use this extension, enable it in Safari settings" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dGt-Ve-8bH">
+                                <rect key="frame" x="20" y="215" width="353" height="41"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="dGt-Ve-8bF" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Jgc-Nh-gRC"/>
+                            <constraint firstItem="dGt-Ve-8bF" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Jgc-Nh-gRD"/>
+                            <constraint firstItem="dGt-Ve-8bG" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="100" id="Jgc-Nh-gRE"/>
+                            <constraint firstItem="dGt-Ve-8bG" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Jgc-Nh-gRF"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dGt-Ve-8bG" secondAttribute="trailing" constant="20" id="Jgc-Nh-gRG"/>
+                            <constraint firstItem="dGt-Ve-8bH" firstAttribute="top" secondItem="dGt-Ve-8bG" secondAttribute="bottom" constant="20" id="Jgc-Nh-gRH"/>
+                            <constraint firstItem="dGt-Ve-8bH" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Jgc-Nh-gRI"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="dGt-Ve-8bH" secondAttribute="trailing" constant="20" id="Jgc-Nh-gRJ"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="enableExtensionButton" destination="dGt-Ve-8bF" id="Jgc-Nh-gRK"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="132" y="-27"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/safari-extension/ChronicleSync/Info.plist
+++ b/safari-extension/ChronicleSync/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/safari-extension/ChronicleSync/SceneDelegate.swift
+++ b/safari-extension/ChronicleSync/SceneDelegate.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}

--- a/safari-extension/ChronicleSync/ViewController.swift
+++ b/safari-extension/ChronicleSync/ViewController.swift
@@ -1,0 +1,44 @@
+import UIKit
+import SafariServices
+import WebKit
+
+class ViewController: UIViewController {
+    
+    @IBOutlet weak var enableExtensionButton: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    private func setupUI() {
+        title = "ChronicleSync"
+        
+        if enableExtensionButton == nil {
+            let button = UIButton(type: .system)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.setTitle("Enable Safari Extension", for: .normal)
+            button.addTarget(self, action: #selector(openSafariExtensionPreferences), for: .touchUpInside)
+            
+            view.addSubview(button)
+            
+            NSLayoutConstraint.activate([
+                button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            ])
+            
+            enableExtensionButton = button
+        }
+    }
+    
+    @IBAction func openSafariExtensionPreferences(_ sender: Any) {
+        SFSafariApplication.showPreferencesForExtension(withIdentifier: "com.chroniclesync.ChronicleSync.Extension") { error in
+            guard error == nil else {
+                // Handle error
+                print("Error opening Safari extension preferences: \(error!)")
+                return
+            }
+            // Successfully opened preferences
+        }
+    }
+}

--- a/safari-extension/README.md
+++ b/safari-extension/README.md
@@ -1,0 +1,48 @@
+# ChronicleSync Safari Extension
+
+This directory contains the Safari extension for ChronicleSync, which allows you to use ChronicleSync with Safari on iOS and macOS.
+
+## Documentation
+
+- [Setup Guide](./SETUP_GUIDE.md) - Step-by-step instructions for setting up the Safari extension
+- [Troubleshooting Guide](./TROUBLESHOOTING.md) - Solutions for common issues with the Safari extension
+
+## Building the Extension
+
+The Safari extension is built using the Chrome extension as a base, with additional configuration for Safari.
+
+### Prerequisites
+
+- Xcode 14.0 or later
+- Apple Developer account
+- Node.js and npm
+
+### Build Process
+
+1. Build the Chrome extension first:
+```bash
+cd ../extension
+npm ci
+npm run build
+npm run build:extension
+```
+
+2. Build the Safari extension:
+```bash
+cd ../safari-extension
+./build-safari-extension.sh
+```
+
+## Testing
+
+You can test the Safari extension using:
+
+```bash
+./test-safari-extension.sh
+```
+
+This will build the extension and launch it in the iOS Simulator.
+
+## CI/CD
+
+The Safari extension is built and tested as part of the CI/CD pipeline. See the GitHub workflow file for details.

--- a/safari-extension/README.md
+++ b/safari-extension/README.md
@@ -7,6 +7,14 @@ This directory contains the Safari extension for ChronicleSync, which allows you
 - [Setup Guide](./SETUP_GUIDE.md) - Step-by-step instructions for setting up the Safari extension
 - [Troubleshooting Guide](./TROUBLESHOOTING.md) - Solutions for common issues with the Safari extension
 
+## Safari Extension Structure
+
+The Safari extension consists of two components:
+1. **Container App** (`com.chroniclesync.ChronicleSync`): The iOS app that users install from the App Store
+2. **Safari Web Extension** (`com.chroniclesync.ChronicleSync.Extension`): The extension that runs within Safari
+
+Both components need to be signed with a provisioning profile that includes the appropriate entitlements.
+
 ## Building the Extension
 
 The Safari extension is built using the Chrome extension as a base, with additional configuration for Safari.
@@ -16,6 +24,7 @@ The Safari extension is built using the Chrome extension as a base, with additio
 - Xcode 14.0 or later
 - Apple Developer account
 - Node.js and npm
+- Provisioning profile that covers both the app and extension bundle IDs
 
 ### Build Process
 

--- a/safari-extension/SETUP_GUIDE.md
+++ b/safari-extension/SETUP_GUIDE.md
@@ -68,12 +68,10 @@ Add the following secrets to your GitHub repository:
 2. Add the following secrets:
    - `APPLE_CERTIFICATE_CONTENT`: Paste the base64-encoded certificate
    - `APPLE_CERTIFICATE_PASSWORD`: The password you set for the .p12 file
-   - `APPLE_APP_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile for the main app
-   - `APPLE_EXTENSION_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile for the Safari extension
+   - `APPLE_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile (must include both app and extension)
    - `APPLE_TEAM_ID`: Your Apple Developer Team ID (found in the Apple Developer Portal)
-   - `APPLE_APP_ID`: Your app's bundle identifier (e.g., "com.yourcompany.chroniclesync")
 
-**Note:** For backward compatibility, you can also set `APPLE_PROVISIONING_PROFILE` with a single provisioning profile, but it's recommended to use separate profiles for the app and extension.
+**Important:** Your provisioning profile must include both the main app bundle ID (`com.chroniclesync.ChronicleSync`) and the extension bundle ID (`com.chroniclesync.ChronicleSync.Extension`). This is typically a wildcard provisioning profile or one specifically configured for both bundle IDs.
 
 ### Step 4: Update Xcode Project Configuration
 

--- a/safari-extension/SETUP_GUIDE.md
+++ b/safari-extension/SETUP_GUIDE.md
@@ -68,9 +68,12 @@ Add the following secrets to your GitHub repository:
 2. Add the following secrets:
    - `APPLE_CERTIFICATE_CONTENT`: Paste the base64-encoded certificate
    - `APPLE_CERTIFICATE_PASSWORD`: The password you set for the .p12 file
-   - `APPLE_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile
+   - `APPLE_APP_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile for the main app
+   - `APPLE_EXTENSION_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile for the Safari extension
    - `APPLE_TEAM_ID`: Your Apple Developer Team ID (found in the Apple Developer Portal)
    - `APPLE_APP_ID`: Your app's bundle identifier (e.g., "com.yourcompany.chroniclesync")
+
+**Note:** For backward compatibility, you can also set `APPLE_PROVISIONING_PROFILE` with a single provisioning profile, but it's recommended to use separate profiles for the app and extension.
 
 ### Step 4: Update Xcode Project Configuration
 

--- a/safari-extension/SETUP_GUIDE.md
+++ b/safari-extension/SETUP_GUIDE.md
@@ -1,0 +1,110 @@
+# iOS Safari Extension Setup Guide for ChronicleSync
+
+This guide provides step-by-step instructions for setting up and configuring the iOS Safari extension for ChronicleSync.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+- An Apple Developer account ($99/year)
+- Xcode installed on your Mac
+- Access to your GitHub repository settings to configure secrets
+
+## Step-by-Step Guide
+
+### Step 1: Create Apple Developer Certificates and Provisioning Profiles
+
+1. **Create a Certificate Signing Request (CSR)**:
+   - Open Keychain Access on your Mac
+   - Go to Keychain Access > Certificate Assistant > Request a Certificate from a Certificate Authority
+   - Enter your email and name
+   - Select "Save to disk" and save the CSR file
+
+2. **Create a Development Certificate**:
+   - Log in to [Apple Developer Portal](https://developer.apple.com/account)
+   - Go to Certificates, IDs & Profiles > Certificates > + (Add)
+   - Select "iOS App Development" and upload your CSR file
+   - Download the certificate and double-click to install it in Keychain Access
+
+3. **Register App Identifiers**:
+   - In the Apple Developer Portal, go to Identifiers > + (Add)
+   - Select "App IDs" and then "App"
+   - Enter a description (e.g., "ChronicleSync")
+   - Enter a Bundle ID (e.g., "com.yourcompany.chroniclesync")
+   - Under Capabilities, enable "Safari Extensions"
+   - Click Continue and Register
+
+4. **Create a Provisioning Profile**:
+   - In the Apple Developer Portal, go to Profiles > + (Add)
+   - Select "iOS App Development"
+   - Select your App ID
+   - Select your development certificate
+   - Select devices (or all devices)
+   - Enter a profile name (e.g., "ChronicleSync Development")
+   - Download the provisioning profile
+
+### Step 2: Export Certificate for CI/CD
+
+1. **Export Certificate and Private Key**:
+   - Open Keychain Access
+   - Find your iOS Development certificate
+   - Right-click and select "Export"
+   - Choose the .p12 format and set a password
+   - Save the file
+
+2. **Encode Certificate for GitHub Secrets**:
+   - Open Terminal
+   - Run: `base64 -i /path/to/your/certificate.p12 | pbcopy`
+   - This copies the base64-encoded certificate to your clipboard
+
+3. **Encode Provisioning Profile for GitHub Secrets**:
+   - Run: `base64 -i /path/to/your/profile.mobileprovision | pbcopy`
+   - This copies the base64-encoded provisioning profile to your clipboard
+
+### Step 3: Configure GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+1. Go to your GitHub repository > Settings > Secrets and variables > Actions
+2. Add the following secrets:
+   - `APPLE_CERTIFICATE_CONTENT`: Paste the base64-encoded certificate
+   - `APPLE_CERTIFICATE_PASSWORD`: The password you set for the .p12 file
+   - `APPLE_PROVISIONING_PROFILE`: Paste the base64-encoded provisioning profile
+   - `APPLE_TEAM_ID`: Your Apple Developer Team ID (found in the Apple Developer Portal)
+   - `APPLE_APP_ID`: Your app's bundle identifier (e.g., "com.yourcompany.chroniclesync")
+
+### Step 4: Update Xcode Project Configuration
+
+1. Open the Xcode project:
+```bash
+cd safari-extension
+open ChronicleSync.xcodeproj
+```
+
+2. Configure signing for both targets:
+   - Select the "ChronicleSync" target
+   - Go to Signing & Capabilities
+   - Set Team to your Apple Developer Team
+   - Set Bundle Identifier to match your `APPLE_APP_ID`
+   - Repeat for the "ChronicleSync Extension" target
+
+3. Update Info.plist files if needed to ensure bundle identifiers are consistent
+
+### Step 5: Testing Locally
+
+To test your Safari extension locally:
+
+1. Build and run the project in Xcode:
+```bash
+cd safari-extension
+xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Debug -sdk iphoneos -destination 'platform=iOS Simulator,name=iPhone 15' build
+```
+
+2. Or use the provided script:
+```bash
+cd safari-extension
+./test-safari-extension.sh
+```
+
+## Troubleshooting
+
+If you encounter issues during setup or building, refer to the [Troubleshooting Guide](./TROUBLESHOOTING.md) for common problems and solutions.

--- a/safari-extension/TROUBLESHOOTING.md
+++ b/safari-extension/TROUBLESHOOTING.md
@@ -1,0 +1,186 @@
+# iOS Safari Extension Troubleshooting Guide
+
+This guide addresses common issues encountered when setting up, building, and deploying Safari extensions for iOS.
+
+## Common Build and Signing Issues
+
+### 1. "No profiles for ... were found"
+
+**Error message:**
+```
+No profiles for '***' were found: Xcode couldn't find any iOS App Development provisioning profiles matching '***'. Automatic signing is disabled and unable to generate a profile.
+```
+
+**Possible causes and solutions:**
+
+- **Mismatched bundle identifier:**
+  - Ensure the bundle identifier in your Xcode project matches the one in your provisioning profile
+  - Verify the `APPLE_APP_ID` secret matches your actual bundle identifier
+  - Check: `Xcode > Target > Signing & Capabilities > Bundle Identifier`
+
+- **Missing or expired provisioning profile:**
+  - Generate a new provisioning profile in the [Apple Developer Portal](https://developer.apple.com/account/resources/profiles/list)
+  - Ensure the profile includes the Safari Extension entitlement
+  - Re-encode and update the `APPLE_PROVISIONING_PROFILE` secret
+
+- **Incorrect Team ID:**
+  - Verify your `APPLE_TEAM_ID` secret matches your Apple Developer Team ID
+  - Find your Team ID in the [Apple Developer Portal](https://developer.apple.com/account/#/membership)
+
+- **Fix in CI workflow:**
+  - Add the `-allowProvisioningUpdates` flag to the xcodebuild command:
+  ```yaml
+  xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive DEVELOPMENT_TEAM="${APPLE_TEAM_ID}" PRODUCT_BUNDLE_IDENTIFIER="${APPLE_APP_ID}" -allowProvisioningUpdates
+  ```
+
+### 2. "Unable to find a matching code-signing identity"
+
+**Error message:**
+```
+Unable to find a matching code-signing identity for '***': No code-signing identities (i.e. certificate and private key pairs) matching '***' were found.
+```
+
+**Possible causes and solutions:**
+
+- **Certificate not properly installed:**
+  - Verify the certificate is correctly installed in the CI environment
+  - Check the base64 encoding of your certificate (no line breaks)
+  - Ensure the certificate password is correct
+
+- **Expired certificate:**
+  - Check certificate expiration in Keychain Access
+  - Generate a new certificate in the Apple Developer Portal
+  - Re-export, encode, and update the `APPLE_CERTIFICATE_CONTENT` secret
+
+- **Keychain access issues:**
+  - Ensure the keychain is unlocked in the CI environment
+  - Add debugging to verify certificate installation:
+  ```bash
+  security find-identity -v -p codesigning
+  ```
+
+### 3. "Code signing is required for product type 'Application'"
+
+**Error message:**
+```
+Code signing is required for product type 'Application' in SDK 'iOS ...'
+```
+
+**Possible causes and solutions:**
+
+- **Automatic signing disabled:**
+  - Enable automatic signing in exportOptions.plist:
+  ```xml
+  <key>signingStyle</key>
+  <string>automatic</string>
+  ```
+
+- **Missing development team:**
+  - Ensure `DEVELOPMENT_TEAM` parameter is passed to xcodebuild
+  - Verify the team ID is correct
+
+- **Manual signing configuration issues:**
+  - If using manual signing, ensure CODE_SIGN_IDENTITY and PROVISIONING_PROFILE_SPECIFIER are set correctly
+  - Example:
+  ```bash
+  xcodebuild ... CODE_SIGN_IDENTITY="iPhone Developer" PROVISIONING_PROFILE_SPECIFIER="YourProfileName"
+  ```
+
+## Safari Extension Specific Issues
+
+### 1. "Safari Extension not appearing in Settings"
+
+**Possible causes and solutions:**
+
+- **Extension not properly bundled:**
+  - Verify the extension is included in the app bundle
+  - Check Info.plist configuration for NSExtension entries
+
+- **Missing entitlements:**
+  - Ensure the app has the com.apple.developer.safari-web-extension entitlement
+  - Check entitlements file or add it in Xcode under Signing & Capabilities
+
+- **Extension resources missing:**
+  - Verify all required extension files are copied to the Resources directory
+  - Check the CI workflow copy commands for any errors
+
+### 2. "Extension fails to load or crashes"
+
+**Possible causes and solutions:**
+
+- **JavaScript compatibility issues:**
+  - Check for Safari-specific JavaScript incompatibilities
+  - Test with Safari's Web Inspector
+  - Add console.log statements to debug initialization
+
+- **Missing permissions:**
+  - Verify required permissions are declared in the extension manifest
+  - Check Info.plist for proper configuration
+
+- **Resource loading issues:**
+  - Ensure paths to resources are correct
+  - Check for CORS or content security policy issues
+
+## CI/CD Specific Issues
+
+### 1. "Secrets not properly configured"
+
+**Possible causes and solutions:**
+
+- **Missing or invalid secrets:**
+  - Verify all required secrets are set in GitHub repository settings
+  - Check for any special characters that might need escaping
+
+- **Secret format issues:**
+  - Ensure certificates and profiles are properly base64 encoded
+  - Avoid line breaks in base64-encoded secrets
+
+- **Debug secret usage:**
+  - Add echo statements to verify secret availability (without revealing content)
+  ```bash
+  if [ -z "$APPLE_TEAM_ID" ]; then echo "APPLE_TEAM_ID is not set"; else echo "APPLE_TEAM_ID is set"; fi
+  ```
+
+### 2. "Simulator or device issues"
+
+**Possible causes and solutions:**
+
+- **Simulator not available:**
+  - List available simulators:
+  ```bash
+  xcrun simctl list devices available
+  ```
+
+- **Device compatibility:**
+  - Ensure the app is built for the correct iOS version
+  - Check minimum deployment target in Xcode
+
+## Advanced Debugging Techniques
+
+### 1. Verbose build output
+
+Add verbose flags to xcodebuild for more detailed output:
+```bash
+xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -verbose
+```
+
+### 2. Inspect provisioning profile
+
+Decode and inspect the provisioning profile content:
+```bash
+security cms -D -i ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
+```
+
+### 3. Check entitlements
+
+Verify the entitlements in the built app:
+```bash
+codesign -d --entitlements :- /path/to/built/app.app
+```
+
+### 4. Safari extension debugging
+
+Enable Web Inspector for Safari extensions:
+1. Enable Developer menu in Safari: `Safari > Preferences > Advanced > Show Develop menu`
+2. Connect iOS device and enable Web Inspector: `Settings > Safari > Advanced > Web Inspector`
+3. Use Safari's Develop menu to inspect the extension

--- a/safari-extension/TROUBLESHOOTING.md
+++ b/safari-extension/TROUBLESHOOTING.md
@@ -25,8 +25,8 @@ No Accounts: Add a new account in Accounts settings.
 - **Missing or expired provisioning profile:**
   - Generate a new provisioning profile in the [Apple Developer Portal](https://developer.apple.com/account/resources/profiles/list)
   - Ensure the profile includes the Safari Extension entitlement
-  - Create separate profiles for the main app and the extension
-  - Re-encode and update the `APPLE_APP_PROVISIONING_PROFILE` and `APPLE_EXTENSION_PROVISIONING_PROFILE` secrets
+  - Make sure the profile covers both the main app bundle ID (`com.chroniclesync.ChronicleSync`) and the extension bundle ID (`com.chroniclesync.ChronicleSync.Extension`)
+  - Re-encode and update the `APPLE_PROVISIONING_PROFILE` secret
 
 - **Incorrect Team ID:**
   - Verify your `APPLE_TEAM_ID` secret matches your Apple Developer Team ID

--- a/safari-extension/build-safari-extension.sh
+++ b/safari-extension/build-safari-extension.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Define paths
+EXTENSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/extension"
+SAFARI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAFARI_RESOURCES_DIR="$SAFARI_DIR/ChronicleSync Extension/Resources"
+
+# Build the Chrome extension first
+echo "Building Chrome extension..."
+cd "$EXTENSION_DIR"
+npm ci
+npm run build
+
+# Create Safari extension resources directory if it doesn't exist
+mkdir -p "$SAFARI_RESOURCES_DIR"
+
+# Copy extension files to Safari extension
+echo "Copying extension files to Safari extension..."
+cp "$EXTENSION_DIR/popup.html" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/popup.css" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/settings.html" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/settings.css" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/history.html" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/history.css" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/devtools.html" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/devtools.css" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/bip39-wordlist.js" "$SAFARI_RESOURCES_DIR/"
+
+# Copy built JS files
+cp "$EXTENSION_DIR/dist/popup.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/background.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/settings.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/history.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/devtools.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/devtools-page.js" "$SAFARI_RESOURCES_DIR/"
+cp "$EXTENSION_DIR/dist/content-script.js" "$SAFARI_RESOURCES_DIR/"
+
+# Copy assets directory if it exists
+if [ -d "$EXTENSION_DIR/dist/assets" ]; then
+  mkdir -p "$SAFARI_RESOURCES_DIR/assets"
+  cp -R "$EXTENSION_DIR/dist/assets/"* "$SAFARI_RESOURCES_DIR/assets/"
+fi
+
+echo "Safari extension resources prepared successfully!"
+
+# Build the Xcode project (requires xcodebuild)
+if command -v xcodebuild &> /dev/null; then
+  echo "Building Safari extension with xcodebuild..."
+  cd "$SAFARI_DIR"
+  xcodebuild -project ChronicleSync.xcodeproj -scheme "ChronicleSync" -configuration Release -sdk iphoneos -archivePath "build/ChronicleSync.xcarchive" archive
+  xcodebuild -exportArchive -archivePath "build/ChronicleSync.xcarchive" -exportOptionsPlist exportOptions.plist -exportPath "build"
+  echo "IPA file created at $SAFARI_DIR/build/ChronicleSync.ipa"
+else
+  echo "xcodebuild not found. Skipping IPA creation."
+  echo "To build the IPA file, run this script on a macOS system with Xcode installed."
+fi

--- a/safari-extension/exportOptions.plist
+++ b/safari-extension/exportOptions.plist
@@ -5,7 +5,7 @@
     <key>method</key>
     <string>development</string>
     <key>teamID</key>
-    <string>XXXXXXXXXX</string>
+    <string>${{ secrets.APPLE_TEAM_ID }}</string>
     <key>compileBitcode</key>
     <false/>
     <key>uploadBitcode</key>

--- a/safari-extension/exportOptions.plist
+++ b/safari-extension/exportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>teamID</key>
+    <string>XXXXXXXXXX</string>
+    <key>compileBitcode</key>
+    <false/>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>signingStyle</key>
+    <string>automatic</string>
+</dict>
+</plist>

--- a/safari-extension/test-safari-extension.sh
+++ b/safari-extension/test-safari-extension.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Define paths
+SAFARI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCREENSHOTS_DIR="$SAFARI_DIR/screenshots"
+
+# Create screenshots directory
+mkdir -p "$SCREENSHOTS_DIR"
+
+# Function to run the simulator and take a screenshot
+take_screenshot() {
+  local DEVICE_ID=$1
+  local SCREENSHOT_NAME=$2
+  
+  echo "Starting simulator with device ID: $DEVICE_ID"
+  xcrun simctl boot "$DEVICE_ID"
+  
+  echo "Installing app on simulator..."
+  xcrun simctl install "$DEVICE_ID" "$SAFARI_DIR/build/ChronicleSync.app"
+  
+  echo "Launching app..."
+  xcrun simctl launch "$DEVICE_ID" "com.chroniclesync.ChronicleSync"
+  
+  # Wait for app to fully launch
+  sleep 5
+  
+  echo "Taking screenshot..."
+  xcrun simctl io "$DEVICE_ID" screenshot "$SCREENSHOTS_DIR/$SCREENSHOT_NAME"
+  
+  echo "Terminating app..."
+  xcrun simctl terminate "$DEVICE_ID" "com.chroniclesync.ChronicleSync"
+  
+  echo "Shutting down simulator..."
+  xcrun simctl shutdown "$DEVICE_ID"
+}
+
+# Check if we have a built app
+if [ ! -d "$SAFARI_DIR/build/ChronicleSync.app" ]; then
+  echo "Error: ChronicleSync.app not found. Please build the app first."
+  exit 1
+fi
+
+# Get available simulators
+echo "Available simulators:"
+DEVICE_ID=$(xcrun simctl list devices available | grep "iPhone" | head -1 | sed -E 's/.*\(([A-Za-z0-9-]+)\).*/\1/')
+
+if [ -z "$DEVICE_ID" ]; then
+  echo "Error: No available iPhone simulator found."
+  exit 1
+fi
+
+echo "Using simulator with device ID: $DEVICE_ID"
+
+# Take screenshot
+take_screenshot "$DEVICE_ID" "chroniclesync_screenshot.png"
+
+echo "Test completed successfully!"
+echo "Screenshot saved to: $SCREENSHOTS_DIR/chroniclesync_screenshot.png"


### PR DESCRIPTION
This PR addresses the CI failure in the Safari extension build by:

1. Switching to manual signing for CI environments
2. Simplifying the provisioning profile setup to use a single profile for both app and extension
3. Using symbolic links to ensure the profile is available with the expected names
4. Hardcoding the bundle identifiers in the CI workflow for reliability
5. Creating comprehensive documentation:
   - A detailed setup guide for iOS Safari extensions
   - A troubleshooting guide for common issues
   - Updated README with references to the new guides

These changes should fix both the "No profiles for ... were found" and "No Accounts: Add a new account in Accounts settings" errors in the CI build.

### Required GitHub Secrets

- `APPLE_CERTIFICATE_CONTENT`: Base64-encoded certificate
- `APPLE_CERTIFICATE_PASSWORD`: Certificate password
- `APPLE_PROVISIONING_PROFILE`: Base64-encoded provisioning profile (must cover both app and extension bundle IDs)
- `APPLE_TEAM_ID`: Apple Developer Team ID

### Bundle Identifiers

- Main app: `com.chroniclesync.ChronicleSync`
- Extension: `com.chroniclesync.ChronicleSync.Extension`