### PR TITLE
Add iOS Safari Extension

### DIFF
--- a/.github/workflows/safari-extension-build.yml
+++ b/.github/workflows/safari-extension-build.yml
@@ -1,0 +1,68 @@
+name: Build Safari Extension
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'ChronicleSync-Safari/**'
+      - '.github/workflows/safari-extension-build.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'ChronicleSync-Safari/**'
+      - '.github/workflows/safari-extension-build.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      
+      - name: Install dependencies
+        run: |
+          cd ChronicleSync-Safari
+          # Add any dependency installation steps here if needed
+      
+      - name: Build
+        run: |
+          cd ChronicleSync-Safari
+          xcodebuild clean build -project ChronicleSync-Safari.xcodeproj -scheme "ChronicleSync-Safari" -destination "platform=iOS Simulator,name=iPhone 14" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+      
+      - name: Run Tests
+        run: |
+          cd ChronicleSync-Safari
+          xcodebuild test -project ChronicleSync-Safari.xcodeproj -scheme "ChronicleSync-Safari" -destination "platform=iOS Simulator,name=iPhone 14" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+      
+      - name: Archive
+        run: |
+          cd ChronicleSync-Safari
+          xcodebuild archive -project ChronicleSync-Safari.xcodeproj -scheme "ChronicleSync-Safari" -archivePath "build/ChronicleSync-Safari.xcarchive" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+      
+      - name: Create IPA
+        run: |
+          cd ChronicleSync-Safari
+          mkdir -p build/Payload
+          cp -r build/ChronicleSync-Safari.xcarchive/Products/Applications/ChronicleSync-Safari.app build/Payload/
+          cd build
+          zip -r ChronicleSync-Safari.ipa Payload
+      
+      - name: Upload IPA
+        uses: actions/upload-artifact@v3
+        with:
+          name: ChronicleSync-Safari-IPA
+          path: ChronicleSync-Safari/build/ChronicleSync-Safari.ipa
+      
+      - name: Upload Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: ChronicleSync-Safari-Archive
+          path: ChronicleSync-Safari/build/ChronicleSync-Safari.xcarchive

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Info.plist
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>ChronicleSync Safari Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2023 ChronicleSync. All rights reserved.</string>
+</dict>
+</plist>

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/background.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/background.ts
@@ -1,0 +1,327 @@
+import { getConfig } from '../config';
+import { HistoryStore } from './db/HistoryStore';
+import { getSystemInfo } from './utils/system';
+import { HistoryEntry, DeviceInfo } from './types';
+
+interface SyncResponse {
+  history?: HistoryEntry[];
+  devices?: DeviceInfo[];
+  lastSyncTime?: number;
+}
+
+interface SyncStats {
+  sent: number;
+  received: number;
+  devices: number;
+}
+
+const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+async function initializeExtension(): Promise<boolean> {
+  try {
+    await chrome.storage.local.get(['initialized']);
+    await getConfig();
+    await chrome.storage.local.set({ initialized: true });
+    return true;
+  } catch (error) {
+    console.error('Failed to initialize extension:', error);
+    return false;
+  }
+}
+
+async function syncHistory(forceFullSync = false): Promise<void> {
+  try {
+    const initialized = await chrome.storage.local.get(['initialized']);
+    if (!initialized.initialized) {
+      const success = await initializeExtension();
+      if (!success) {
+        console.debug('Sync skipped: Extension not initialized');
+        return;
+      }
+    }
+
+    const config = await getConfig();
+
+    if (!config.clientId || config.clientId === 'extension-default') {
+      console.debug('Sync paused: No client ID configured');
+      throw new Error('Please configure your Client ID in the extension popup');
+    }
+
+    console.debug('Starting sync with client ID:', config.clientId);
+
+    const systemInfo = await getSystemInfo();
+    const now = Date.now();
+
+    const stored = await chrome.storage.local.get(['lastSync']);
+    const storedLastSync = stored.lastSync || 0;
+
+    const startTime = forceFullSync ? 0 : storedLastSync;
+
+    const historyStore = new HistoryStore();
+    await historyStore.init();
+
+    await historyStore.updateDevice(systemInfo);
+
+    const historyItems = await chrome.history.search({
+      text: '',
+      startTime: startTime,
+      endTime: now,
+      maxResults: 10000
+    });
+
+    const historyData = await Promise.all(historyItems.map(async item => {
+      if (!item.url) return [];
+      const visits = await chrome.history.getVisits({ url: item.url });
+      
+      return visits
+        .filter((visit: chrome.history.VisitItem) => {
+          const visitTime = visit.visitTime || 0;
+          return visitTime >= startTime && visitTime <= now;
+        })
+        .map((visit: chrome.history.VisitItem) => ({
+          url: item.url!,
+          title: item.title || '',
+          visitTime: visit.visitTime || Date.now(),
+          visitId: visit.visitId.toString(),
+          referringVisitId: visit.referringVisitId?.toString() || '0',
+          transition: visit.transition || 'link',
+          ...systemInfo
+        }));
+    }));
+
+    const flattenedHistoryData = historyData.flat();
+    
+    for (const entry of flattenedHistoryData) {
+      await historyStore.addEntry(entry);
+    }
+
+    const unsyncedEntries = await historyStore.getUnsyncedEntries();
+
+    if (unsyncedEntries.length > 0) {
+      const response = await fetch(`${config.apiEndpoint}?clientId=${encodeURIComponent(config.clientId)}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          history: unsyncedEntries,
+          deviceInfo: systemInfo,
+          lastSync: storedLastSync
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const syncResponse: SyncResponse = await response.json();
+
+      if (syncResponse.history && syncResponse.history.length > 0) {
+        await historyStore.mergeRemoteEntries(syncResponse.history);
+      }
+
+      if (syncResponse.devices) {
+        for (const device of syncResponse.devices) {
+          await historyStore.updateDevice(device);
+        }
+      }
+
+      for (const entry of unsyncedEntries) {
+        await historyStore.markAsSynced(entry.visitId);
+      }
+
+      const newLastSync = syncResponse.lastSyncTime || now;
+      const lastSyncDate = new Date(newLastSync).toLocaleString();
+      await chrome.storage.local.set({ lastSync: newLastSync });
+      await chrome.storage.sync.set({ lastSync: lastSyncDate });
+
+      try {
+        chrome.runtime.sendMessage({ 
+          type: 'syncComplete',
+          stats: {
+            sent: unsyncedEntries.length,
+            received: syncResponse.history?.length || 0,
+            devices: syncResponse.devices?.length || 0
+          } as SyncStats
+        }).catch(() => {
+          // Ignore error when no receivers are present
+        });
+      } catch {
+        // Catch any other messaging errors
+      }
+    }
+
+    console.debug('Successfully completed sync');
+  } catch (error) {
+    console.error('Error syncing history:', error);
+    try {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      chrome.runtime.sendMessage({ 
+        type: 'syncError',
+        error: errorMessage
+      }).catch(() => {
+        // Ignore error when no receivers are present
+      });
+    } catch {
+      // Catch any other messaging errors
+    }
+  }
+}
+
+// Initial sync with full history
+syncHistory(true);
+
+// Set up periodic sync
+setInterval(() => syncHistory(false), SYNC_INTERVAL);
+
+// Listen for navigation events
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, _tab) => {
+  if (changeInfo.url) {
+    console.debug(`Navigation to: ${changeInfo.url}`);
+    setTimeout(() => syncHistory(false), 1000);
+  }
+});
+
+// Listen for messages from the page
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'getClientId') {
+    chrome.storage.local.get(['initialized']).then(async result => {
+      if (!result.initialized) {
+        const success = await initializeExtension();
+        if (!success) {
+          sendResponse({ error: 'Extension not initialized' });
+          return;
+        }
+      }
+
+      try {
+        const config = await getConfig();
+        sendResponse({ clientId: config.clientId === 'extension-default' ? null : config.clientId });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error getting client ID:', errorMessage);
+        sendResponse({ error: 'Failed to get client ID' });
+      }
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'triggerSync') {
+    syncHistory(true)
+      .then(() => {
+        sendResponse({ success: true, message: 'Sync successful' });
+      })
+      .catch(error => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Manual sync failed:', errorMessage);
+        sendResponse({ error: errorMessage });
+      });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'getHistory') {
+    const { deviceId, since, limit } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const entries = await historyStore.getEntries(deviceId, since);
+        const limitedEntries = limit ? entries.slice(0, limit) : entries;
+        sendResponse(limitedEntries);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error fetching history from IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'getDevices') {
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const devices = await historyStore.getDevices();
+        sendResponse(devices);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error fetching devices from IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'deleteHistory') {
+    const { visitId } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        await historyStore.deleteEntry(visitId);
+        await syncHistory(false);
+        sendResponse({ success: true });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error deleting history entry:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'pageContentExtracted') {
+    // Handle page content extraction from content script
+    const { url, content, summary } = request.data;
+    if (url && (content || summary)) {
+      const historyStore = new HistoryStore();
+      historyStore.init().then(async () => {
+        try {
+          await historyStore.updatePageContent(url, { content, summary });
+          console.debug('Updated page content for:', url);
+          sendResponse({ success: true });
+          
+          // Trigger a sync to send the updated content to the server
+          setTimeout(() => syncHistory(false), 1000);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          console.error('Error updating page content:', errorMessage);
+          sendResponse({ error: errorMessage });
+        }
+      }).catch(error => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error initializing IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      });
+      return true; // Will respond asynchronously
+    }
+  } else if (request.type === 'searchHistory') {
+    const { query } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const results = await historyStore.searchContent(query);
+        
+        // Format the results for display
+        const formattedResults = results.map(result => ({
+          visitId: result.entry.visitId,
+          url: result.entry.url,
+          title: result.entry.title,
+          visitTime: result.entry.visitTime,
+          matches: result.matches
+        }));
+        
+        sendResponse({ success: true, results: formattedResults });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error searching history:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  }
+});

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/components/SearchHistory.tsx
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/components/SearchHistory.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { SearchResult } from '../types';
+
+interface SearchHistoryProps {
+  onSearchComplete: (results: SearchResult[]) => void;
+}
+
+export const SearchHistory: React.FC<SearchHistoryProps> = ({ onSearchComplete }) => {
+  const [query, setQuery] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!query.trim()) {
+      setError('Please enter a search term');
+      return;
+    }
+    
+    setIsSearching(true);
+    setError(null);
+    
+    try {
+      const response = await chrome.runtime.sendMessage({
+        type: 'searchHistory',
+        query: query.trim()
+      });
+      
+      if (response.error) {
+        setError(response.error);
+      } else if (response.success) {
+        onSearchComplete(response.results);
+      }
+    } catch (err) {
+      setError('Failed to search history: ' + String(err));
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  return (
+    <div className="search-container">
+      <form onSubmit={handleSearch}>
+        <div className="search-input-container">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search page content..."
+            className="search-input"
+          />
+          <button 
+            type="submit" 
+            className="search-button"
+            disabled={isSearching}
+          >
+            {isSearching ? 'Searching...' : 'Search'}
+          </button>
+        </div>
+        {error && <div className="search-error">{error}</div>}
+      </form>
+    </div>
+  );
+};
+
+interface SearchResultsProps {
+  results: SearchResult[];
+  onClearResults: () => void;
+}
+
+export const SearchResults: React.FC<SearchResultsProps> = ({ results, onClearResults }) => {
+  if (results.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="search-results">
+      <div className="search-results-header">
+        <h3>Search Results ({results.length})</h3>
+        <button onClick={onClearResults} className="clear-results-button">Clear Results</button>
+      </div>
+      
+      <div className="search-results-list">
+        {results.map((result) => (
+          <div key={result.visitId} className="search-result-item">
+            <div className="search-result-title">
+              <a href={result.url} target="_blank" rel="noopener noreferrer">
+                {result.title || result.url}
+              </a>
+              <span className="search-result-time">
+                {new Date(result.visitTime).toLocaleString()}
+              </span>
+            </div>
+            
+            <div className="search-result-matches">
+              {result.matches.slice(0, 3).map((match, index) => (
+                <div key={index} className="search-result-match">
+                  <div className="search-result-context">
+                    {match.context.replace(match.text, `<mark>${match.text}</mark>`)}
+                  </div>
+                </div>
+              ))}
+              {result.matches.length > 3 && (
+                <div className="search-result-more">
+                  +{result.matches.length - 3} more matches
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/config.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/config.ts
@@ -1,0 +1,11 @@
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const paths = {
+  extensionDist: resolve(__dirname, '../dist'),
+  popup: resolve(__dirname, '../popup.html'),
+  background: resolve(__dirname, '../background.js'),
+  extension: resolve(__dirname, '../dist')
+};

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/content-script.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/content-script.ts
@@ -1,0 +1,74 @@
+// Content script to extract and summarize webpage content
+import { extractPageContent } from './utils/content-extractor';
+
+// Extract content when the page loads
+function processPageContent() {
+  try {
+    const pageContent = extractPageContent();
+    
+    // Send the extracted content to the background script
+    chrome.runtime.sendMessage({
+      type: 'pageContentExtracted',
+      data: {
+        url: window.location.href,
+        title: document.title,
+        content: pageContent.content,
+        summary: pageContent.summary,
+        timestamp: Date.now()
+      }
+    });
+  } catch (error) {
+    console.error('Error extracting page content:', error);
+  }
+}
+
+// Process content after the page has fully loaded
+window.addEventListener('load', () => {
+  // Wait a bit for dynamic content to load
+  setTimeout(processPageContent, 1000);
+});
+
+// Listen for messages from the background script
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'searchPageContent') {
+    const { query } = request;
+    try {
+      const pageContent = extractPageContent();
+      const searchResults = searchContent(pageContent.content, query);
+      sendResponse({ success: true, results: searchResults });
+    } catch (error) {
+      sendResponse({ success: false, error: String(error) });
+    }
+    return true; // Will respond asynchronously
+  }
+});
+
+// Function to search content and return matches with context
+function searchContent(content: string, query: string): { text: string, context: string }[] {
+  if (!query || !content) return [];
+  
+  const results: { text: string, context: string }[] = [];
+  const lowerContent = content.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  
+  let startIndex = 0;
+  while (startIndex < lowerContent.length) {
+    const foundIndex = lowerContent.indexOf(lowerQuery, startIndex);
+    if (foundIndex === -1) break;
+    
+    // Get context around the match (100 chars before and after)
+    const contextStart = Math.max(0, foundIndex - 100);
+    const contextEnd = Math.min(content.length, foundIndex + query.length + 100);
+    const matchText = content.substring(foundIndex, foundIndex + query.length);
+    const context = content.substring(contextStart, contextEnd);
+    
+    results.push({
+      text: matchText,
+      context: context
+    });
+    
+    startIndex = foundIndex + query.length;
+  }
+  
+  return results;
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/db/HistoryStore.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/db/HistoryStore.ts
@@ -1,0 +1,386 @@
+import { HistoryEntry, DeviceInfo } from '../types';
+
+export class HistoryStore {
+  private readonly DB_NAME = 'chroniclesync';
+  private readonly HISTORY_STORE = 'history';
+  private readonly DEVICE_STORE = 'devices';
+  private readonly DB_VERSION = 3;
+  private db: IDBDatabase | null = null;
+
+  async init(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      console.log('Initializing IndexedDB...');
+      const request = indexedDB.open(this.DB_NAME, this.DB_VERSION);
+
+      request.onerror = () => {
+        console.error('Error opening IndexedDB:', request.error);
+        reject(request.error);
+      };
+      
+      request.onsuccess = () => {
+        console.log('IndexedDB opened successfully');
+        this.db = request.result;
+        resolve();
+      };
+
+      request.onupgradeneeded = (event) => {
+        console.log('Upgrading IndexedDB schema...');
+        const db = (event.target as IDBOpenDBRequest).result;
+        const oldVersion = event.oldVersion;
+        
+        // Create or update history store
+        if (!db.objectStoreNames.contains(this.HISTORY_STORE)) {
+          const store = db.createObjectStore(this.HISTORY_STORE, { keyPath: 'visitId' });
+          store.createIndex('visitTime', 'visitTime');
+          store.createIndex('syncStatus', 'syncStatus');
+          store.createIndex('url', 'url');
+          store.createIndex('deviceId', 'deviceId');
+          store.createIndex('lastModified', 'lastModified');
+          console.log('Created history store with indexes');
+        }
+
+        // Create or update devices store
+        if (!db.objectStoreNames.contains(this.DEVICE_STORE)) {
+          const deviceStore = db.createObjectStore(this.DEVICE_STORE, { keyPath: 'deviceId' });
+          deviceStore.createIndex('lastSeen', 'lastSeen');
+          console.log('Created devices store');
+        }
+        
+        // Add content index for version 3
+        if (oldVersion < 3) {
+          // During onupgradeneeded, we already have an active transaction
+          // We can get the object store directly from the database
+          if (db.objectStoreNames.contains(this.HISTORY_STORE)) {
+            // The transaction is available directly from the event
+            const transaction = event.target as IDBOpenDBRequest;
+            const historyStore = transaction.transaction?.objectStore(this.HISTORY_STORE);
+            
+            // Create index for page content if the store exists and index doesn't exist
+            if (historyStore && !historyStore.indexNames.contains('hasContent')) {
+              historyStore.createIndex('hasContent', 'pageContent', { unique: false });
+              console.log('Added page content index');
+            }
+          }
+        }
+      };
+    });
+  }
+
+  async addEntry(entry: Omit<HistoryEntry, 'syncStatus' | 'lastModified'>): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+
+      const fullEntry: HistoryEntry = {
+        ...entry,
+        syncStatus: 'pending',
+        lastModified: Date.now()
+      };
+
+      const request = store.put(fullEntry);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  }
+
+  async getUnsyncedEntries(): Promise<HistoryEntry[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      const index = store.index('syncStatus');
+      const request = index.getAll('pending');
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+  }
+
+  async markAsSynced(visitId: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      const request = store.get(visitId);
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const entry = request.result;
+        if (entry) {
+          entry.syncStatus = 'synced';
+          entry.lastModified = Date.now();
+          const updateRequest = store.put(entry);
+          updateRequest.onerror = () => reject(updateRequest.error);
+          updateRequest.onsuccess = () => resolve();
+        } else {
+          resolve();
+        }
+      };
+    });
+  }
+
+  async getEntries(deviceId?: string, since?: number): Promise<HistoryEntry[]> {
+    if (!this.db) {
+      console.error('Database not initialized');
+      throw new Error('Database not initialized');
+    }
+
+    return new Promise((resolve, reject) => {
+      console.log('Getting history entries...');
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      
+      let request: IDBRequest;
+      if (deviceId) {
+        const deviceIndex = store.index('deviceId');
+        request = deviceIndex.getAll(deviceId);
+      } else {
+        const timeIndex = store.index('lastModified');
+        request = timeIndex.getAll(since ? IDBKeyRange.lowerBound(since) : undefined);
+      }
+
+      request.onerror = () => {
+        console.error('Error getting entries:', request.error);
+        reject(request.error);
+      };
+      request.onsuccess = () => {
+        const entries = request.result || [];
+        // Filter out deleted entries unless explicitly requested
+        const filteredEntries = entries.filter((entry: HistoryEntry) => !entry.deleted);
+        console.log('Retrieved entries:', filteredEntries.length);
+        resolve(filteredEntries);
+      };
+    });
+  }
+
+  async mergeRemoteEntries(remoteEntries: HistoryEntry[]): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+
+      let completed = 0;
+      let errors = 0;
+
+      remoteEntries.forEach(remoteEntry => {
+        // Get existing entry if any
+        const request = store.get(remoteEntry.visitId);
+
+        request.onerror = () => {
+          errors++;
+          if (completed + errors === remoteEntries.length) {
+            if (errors > 0) {
+              reject(new Error(`Failed to merge ${errors} entries`));
+            } else {
+              resolve();
+            }
+          }
+        };
+
+        request.onsuccess = () => {
+          const localEntry = request.result;
+          
+          // If local entry exists, only update if remote is newer
+          if (!localEntry || remoteEntry.lastModified > localEntry.lastModified) {
+            const putRequest = store.put({
+              ...remoteEntry,
+              syncStatus: 'synced'
+            });
+
+            putRequest.onerror = () => {
+              errors++;
+              if (completed + errors === remoteEntries.length) {
+                if (errors > 0) {
+                  reject(new Error(`Failed to merge ${errors} entries`));
+                } else {
+                  resolve();
+                }
+              }
+            };
+
+            putRequest.onsuccess = () => {
+              completed++;
+              if (completed + errors === remoteEntries.length) {
+                if (errors > 0) {
+                  reject(new Error(`Failed to merge ${errors} entries`));
+                } else {
+                  resolve();
+                }
+              }
+            };
+          } else {
+            completed++;
+            if (completed + errors === remoteEntries.length) {
+              if (errors > 0) {
+                reject(new Error(`Failed to merge ${errors} entries`));
+              } else {
+                resolve();
+              }
+            }
+          }
+        };
+      });
+    });
+  }
+
+  async updateDevice(device: DeviceInfo): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.DEVICE_STORE], 'readwrite');
+      const store = transaction.objectStore(this.DEVICE_STORE);
+
+      const deviceWithTimestamp = {
+        ...device,
+        lastSeen: Date.now()
+      };
+
+      const request = store.put(deviceWithTimestamp);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+  }
+
+  async getDevices(): Promise<DeviceInfo[]> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.DEVICE_STORE], 'readonly');
+      const store = transaction.objectStore(this.DEVICE_STORE);
+      const request = store.getAll();
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result || []);
+    });
+  }
+
+  async deleteEntry(visitId: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      
+      // Soft delete by marking as deleted
+      const request = store.get(visitId);
+      
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const entry = request.result;
+        if (entry) {
+          entry.deleted = true;
+          entry.lastModified = Date.now();
+          entry.syncStatus = 'pending';
+          const updateRequest = store.put(entry);
+          updateRequest.onerror = () => reject(updateRequest.error);
+          updateRequest.onsuccess = () => resolve();
+        } else {
+          resolve();
+        }
+      };
+    });
+  }
+
+  async updatePageContent(url: string, pageContent: { content: string, summary: string }): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      const urlIndex = store.index('url');
+      const request = urlIndex.getAll(url);
+      
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const entries = request.result;
+        if (entries && entries.length > 0) {
+          // Find the most recent entry for this URL
+          const mostRecentEntry = entries.reduce((latest, current) => {
+            return current.visitTime > latest.visitTime ? current : latest;
+          }, entries[0]);
+          
+          // Update the entry with page content
+          mostRecentEntry.pageContent = {
+            content: pageContent.content,
+            summary: pageContent.summary,
+            extractedAt: Date.now()
+          };
+          mostRecentEntry.syncStatus = 'pending';
+          mostRecentEntry.lastModified = Date.now();
+          
+          const updateRequest = store.put(mostRecentEntry);
+          updateRequest.onerror = () => reject(updateRequest.error);
+          updateRequest.onsuccess = () => resolve();
+        } else {
+          // No entries found for this URL
+          resolve();
+        }
+      };
+    });
+  }
+
+  async searchContent(query: string): Promise<{ entry: HistoryEntry, matches: { text: string, context: string }[] }[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    if (!query || query.trim().length === 0) return [];
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(this.HISTORY_STORE);
+      const request = store.getAll();
+      
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const entries = request.result || [];
+        const results: { entry: HistoryEntry, matches: { text: string, context: string }[] }[] = [];
+        
+        // Filter entries with page content and not deleted
+        const entriesWithContent = entries.filter(entry => 
+          !entry.deleted && 
+          entry.pageContent && 
+          entry.pageContent.content
+        );
+        
+        // Search for query in content
+        const lowerQuery = query.toLowerCase();
+        
+        for (const entry of entriesWithContent) {
+          const content = entry.pageContent!.content.toLowerCase();
+          const matches: { text: string, context: string }[] = [];
+          
+          let startIndex = 0;
+          while (startIndex < content.length) {
+            const foundIndex = content.indexOf(lowerQuery, startIndex);
+            if (foundIndex === -1) break;
+            
+            // Get context around the match (100 chars before and after)
+            const contextStart = Math.max(0, foundIndex - 100);
+            const contextEnd = Math.min(content.length, foundIndex + query.length + 100);
+            const matchText = entry.pageContent!.content.substring(foundIndex, foundIndex + query.length);
+            const context = entry.pageContent!.content.substring(contextStart, contextEnd);
+            
+            matches.push({
+              text: matchText,
+              context: context
+            });
+            
+            startIndex = foundIndex + query.length;
+          }
+          
+          if (matches.length > 0) {
+            results.push({
+              entry,
+              matches
+            });
+          }
+        }
+        
+        resolve(results);
+      };
+    });
+  }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/devtools-page.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/devtools-page.ts
@@ -1,0 +1,8 @@
+chrome.devtools.panels.create(
+  'ChronicleSync',
+  'icon-32.png',
+  'devtools.html',
+  () => {
+    // Panel created
+  }
+);

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/devtools.tsx
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/devtools.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { HistoryStore } from './db/HistoryStore';
+
+interface SyncState {
+  lastSync: string;
+  totalEntries: number;
+  syncStatus: string;
+}
+
+const DevTools: React.FC = () => {
+  const [syncState, setSyncState] = useState<SyncState>({
+    lastSync: 'Never',
+    totalEntries: 0,
+    syncStatus: 'Unknown'
+  });
+
+  useEffect(() => {
+    const updateState = async () => {
+      const store = new HistoryStore();
+      await store.init();
+      const entries = await store.getEntries();
+      const unsyncedEntries = await store.getUnsyncedEntries();
+
+      setSyncState({
+        lastSync: entries.length > 0 
+          ? new Date(Math.max(...entries.map(e => e.lastModified))).toLocaleString() 
+          : 'Never',
+        totalEntries: entries.length,
+        syncStatus: unsyncedEntries.length > 0 ? 'Syncing' : 'Synced'
+      });
+    };
+
+    updateState();
+    const interval = setInterval(updateState, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="devtools-container">
+      <div className="section">
+        <h2>Sync Status</h2>
+        <div className="info-row">
+          <span className="info-label">Last Sync:</span>
+          <span className="info-value">{syncState.lastSync}</span>
+        </div>
+        <div className="info-row">
+          <span className="info-label">Total Entries:</span>
+          <span className="info-value">{syncState.totalEntries}</span>
+        </div>
+        <div className="info-row">
+          <span className="info-label">Status:</span>
+          <span className="info-value">{syncState.syncStatus}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<DevTools />);

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.css
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.css
@@ -1,0 +1,208 @@
+.history-container {
+  width: 800px;
+  padding: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.search-tabs {
+  display: flex;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+}
+
+.search-tab {
+  padding: 10px 20px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.search-tab.active {
+  border-bottom: 2px solid #4285f4;
+  font-weight: bold;
+}
+
+.content-search-container {
+  margin-bottom: 20px;
+}
+
+.search-container {
+  margin-bottom: 20px;
+}
+
+.search-input-container {
+  display: flex;
+  gap: 10px;
+}
+
+.search-input {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.search-button {
+  padding: 10px 20px;
+  background-color: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.search-button:disabled {
+  background-color: #ccc;
+}
+
+.search-error {
+  color: #d32f2f;
+  margin-top: 10px;
+}
+
+.search-results {
+  margin-top: 20px;
+}
+
+.search-results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.clear-results-button {
+  padding: 5px 10px;
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search-result-item {
+  background-color: white;
+  padding: 15px;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: 15px;
+}
+
+.search-result-title {
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.search-result-title a {
+  color: #1a73e8;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.search-result-time {
+  color: #666;
+  font-size: 0.8em;
+}
+
+.search-result-match {
+  background-color: #f5f5f5;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.search-result-context {
+  line-height: 1.5;
+}
+
+.search-result-context mark {
+  background-color: #ffeb3b;
+  padding: 2px 0;
+}
+
+.search-result-more {
+  color: #666;
+  font-style: italic;
+  margin-top: 5px;
+}
+
+.page-summary {
+  margin-top: 10px;
+  padding: 8px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+.history-filters {
+  margin-bottom: 16px;
+}
+
+.history-search {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.filter-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.platform-filter,
+.browser-filter {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.history-list {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.history-item {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+.history-item:hover {
+  background-color: #f5f5f5;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.pagination button {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  background: #eee;
+  cursor: not-allowed;
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.html
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chronicle Sync History</title>
+    <link rel="stylesheet" href="history.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="history.js"></script>
+  </body>
+</html>

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.tsx
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/history.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { HistoryStore } from './db/HistoryStore';
+import { SearchHistory, SearchResults } from './components/SearchHistory';
+
+const ITEMS_PER_PAGE = 10;
+
+import { HistoryEntry, SearchResult } from './types';
+
+interface FilterOptions {
+  platform: string;
+  browserName: string;
+}
+
+const HistoryView: React.FC = () => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [filteredHistory, setFilteredHistory] = useState<HistoryEntry[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [filters, setFilters] = useState<FilterOptions>({ platform: '', browserName: '' });
+  const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
+  const [availableBrowsers, setAvailableBrowsers] = useState<string[]>([]);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [showingSearchResults, setShowingSearchResults] = useState(false);
+
+  useEffect(() => {
+    loadHistory();
+  }, []);
+
+  useEffect(() => {
+    if (history.length > 0) {
+      const platforms = [...new Set(history.map(item => item.platform))];
+      const browsers = [...new Set(history.map(item => item.browserName))];
+      setAvailablePlatforms(platforms);
+      setAvailableBrowsers(browsers);
+    }
+  }, [history]);
+
+  useEffect(() => {
+    // If we're showing search results, don't filter the regular history
+    if (showingSearchResults) return;
+    
+    const filtered = history.filter(item => {
+      const matchesSearch = searchTerm === '' || 
+        item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        item.url.toLowerCase().includes(searchTerm.toLowerCase());
+      
+      const matchesPlatform = filters.platform === '' || 
+        item.platform === filters.platform;
+      
+      const matchesBrowser = filters.browserName === '' || 
+        item.browserName === filters.browserName;
+
+      return matchesSearch && matchesPlatform && matchesBrowser;
+    });
+    
+    setFilteredHistory(filtered);
+    setTotalPages(Math.ceil(filtered.length / ITEMS_PER_PAGE));
+    setCurrentPage(1);
+  }, [searchTerm, filters, history, showingSearchResults]);
+  
+  const handleContentSearchComplete = (results: SearchResult[]) => {
+    setSearchResults(results);
+    setShowingSearchResults(true);
+  };
+  
+  const handleClearSearchResults = () => {
+    setSearchResults([]);
+    setShowingSearchResults(false);
+  };
+
+  const loadHistory = async () => {
+    const historyStore = new HistoryStore();
+    await historyStore.init();
+    const items = await historyStore.getEntries();
+    setHistory(items.sort((a, b) => b.visitTime - a.visitTime));
+  };
+
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleFilterChange = (type: keyof FilterOptions, value: string) => {
+    setFilters(prev => ({ ...prev, [type]: value }));
+  };
+
+  const getCurrentPageItems = () => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filteredHistory.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const handleItemClick = (url: string) => {
+    chrome.tabs.create({ url });
+  };
+
+  return (
+    <div className="history-container">
+      <div className="history-header">
+        <h2>Browsing History</h2>
+      </div>
+      
+      <div className="search-tabs">
+        <div className={`search-tab ${!showingSearchResults ? 'active' : ''}`} onClick={handleClearSearchResults}>
+          Basic Search
+        </div>
+        <div className={`search-tab ${showingSearchResults ? 'active' : ''}`} onClick={() => setShowingSearchResults(true)}>
+          Content Search
+        </div>
+      </div>
+      
+      {showingSearchResults ? (
+        <div className="content-search-container">
+          <SearchHistory onSearchComplete={handleContentSearchComplete} />
+          <SearchResults results={searchResults} onClearResults={handleClearSearchResults} />
+        </div>
+      ) : (
+        <>
+          <div className="history-filters">
+            <input
+              type="text"
+              className="history-search"
+              placeholder="Search history..."
+              value={searchTerm}
+              onChange={handleSearch}
+            />
+            <div className="filter-controls">
+              <select
+                value={filters.platform}
+                onChange={(e) => handleFilterChange('platform', e.target.value)}
+                className="platform-filter"
+              >
+                <option value="">All Platforms</option>
+                {availablePlatforms.map(platform => (
+                  <option key={platform} value={platform}>{platform}</option>
+                ))}
+              </select>
+              <select
+                value={filters.browserName}
+                onChange={(e) => handleFilterChange('browserName', e.target.value)}
+                className="browser-filter"
+              >
+                <option value="">All Browsers</option>
+                {availableBrowsers.map(browser => (
+                  <option key={browser} value={browser}>{browser}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="history-list">
+            {getCurrentPageItems().map(item => (
+              <div
+                key={item.visitId}
+                className="history-item"
+                onClick={() => handleItemClick(item.url)}
+              >
+                <div>{item.title}</div>
+                <div style={{ fontSize: '0.8em', color: '#666' }}>
+                  {item.url}
+                  <br />
+                  {new Date(item.visitTime).toLocaleString()}
+                  <br />
+                  <span style={{ color: '#888' }}>
+                    {item.platform} • {item.browserName}
+                  </span>
+                  {item.pageContent && (
+                    <div className="page-summary">
+                      <strong>Summary:</strong> {item.pageContent.summary.substring(0, 150)}
+                      {item.pageContent.summary.length > 150 ? '...' : ''}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="pagination">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+            >
+              Previous
+            </button>
+            <span>
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<HistoryView />);

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/manifest.json
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/manifest.json
@@ -1,0 +1,41 @@
+{
+  "manifest_version": 3,
+  "name": "ChronicleSync Extension",
+  "version": "1.0",
+  "description": "ChronicleSync Safari Extension",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_ui": {
+    "page": "settings.html",
+    "open_in_tab": true
+  },
+  "web_accessible_resources": [{
+    "resources": ["history.html"],
+    "matches": ["<all_urls>"]
+  }],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs",
+    "history",
+    "storage",
+    "unlimitedStorage"
+  ],
+  "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.chroniclesync.xyz/*",
+    "https://api-staging.chroniclesync.xyz/*"
+  ]
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/pages/History.tsx
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/pages/History.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { HistoryEntry, DeviceInfo } from '../types';
+
+const History: React.FC = () => {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [devices, setDevices] = useState<DeviceInfo[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [timeFilter, setTimeFilter] = useState<string>('all'); // all, day, week, month
+
+  useEffect(() => {
+    // Load devices first
+    chrome.runtime.sendMessage({ type: 'getDevices' }, (response) => {
+      if (response.error) {
+        setError(response.error);
+      } else {
+        setDevices(response);
+      }
+    });
+
+    loadHistory();
+  }, []);
+
+  const loadHistory = (deviceId?: string, since?: number) => {
+    setLoading(true);
+    chrome.runtime.sendMessage({
+      type: 'getHistory',
+      deviceId,
+      since
+    }, (response) => {
+      setLoading(false);
+      if (response.error) {
+        setError(response.error);
+      } else {
+        setHistory(response);
+      }
+    });
+  };
+
+  const handleDeviceChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const deviceId = event.target.value;
+    setSelectedDevice(deviceId);
+    loadHistory(deviceId, getTimeFilterValue());
+  };
+
+  const handleTimeFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const filter = event.target.value;
+    setTimeFilter(filter);
+    loadHistory(selectedDevice, getTimeFilterValue());
+  };
+
+  const getTimeFilterValue = (): number | undefined => {
+    const now = Date.now();
+    switch (timeFilter) {
+    case 'day':
+      return now - 24 * 60 * 60 * 1000;
+    case 'week':
+      return now - 7 * 24 * 60 * 60 * 1000;
+    case 'month':
+      return now - 30 * 24 * 60 * 60 * 1000;
+    default:
+      return undefined;
+    }
+  };
+
+  const handleDelete = (visitId: string) => {
+    chrome.runtime.sendMessage({
+      type: 'deleteHistory',
+      visitId
+    }, (response) => {
+      if (response.error) {
+        setError(response.error);
+      } else {
+        // Reload history after deletion
+        loadHistory(selectedDevice, getTimeFilterValue());
+      }
+    });
+  };
+
+  const formatDate = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  const getDeviceName = (deviceId: string) => {
+    const device = devices.find(d => d.deviceId === deviceId);
+    if (!device) return deviceId;
+    return `${device.browserName} on ${device.platform}`;
+  };
+
+  if (error) {
+    return <div className="error">Error: {error}</div>;
+  }
+
+  return (
+    <div className="history-view">
+      <div className="filters">
+        <div className="filter-group">
+          <label htmlFor="device-filter">Device:</label>
+          <select
+            id="device-filter"
+            value={selectedDevice}
+            onChange={handleDeviceChange}
+          >
+            <option value="">All Devices</option>
+            {devices.map(device => (
+              <option key={device.deviceId} value={device.deviceId}>
+                {device.browserName} on {device.platform}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label htmlFor="time-filter">Time:</label>
+          <select
+            id="time-filter"
+            value={timeFilter}
+            onChange={handleTimeFilterChange}
+          >
+            <option value="all">All Time</option>
+            <option value="day">Last 24 Hours</option>
+            <option value="week">Last Week</option>
+            <option value="month">Last Month</option>
+          </select>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="loading">Loading...</div>
+      ) : (
+        <div className="history-list">
+          {history.length === 0 ? (
+            <div className="no-history">No history entries found</div>
+          ) : (
+            history.map(entry => (
+              <div key={entry.visitId} className="history-item">
+                <div className="history-item-header">
+                  <a href={entry.url} target="_blank" rel="noopener noreferrer">
+                    {entry.title || entry.url}
+                  </a>
+                  <button
+                    onClick={() => handleDelete(entry.visitId)}
+                    className="delete-button"
+                    title="Delete"
+                  >
+                    ×
+                  </button>
+                </div>
+                <div className="history-item-meta">
+                  <span className="device-info" title={`${entry.browserName} ${entry.browserVersion}`}>
+                    {getDeviceName(entry.deviceId)}
+                  </span>
+                  <span className="visit-time">
+                    {formatDate(entry.visitTime)}
+                  </span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default History;

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.css
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.css
@@ -1,0 +1,47 @@
+body {
+  width: 400px;
+  height: 600px;
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+.app {
+  padding: 20px;
+}
+
+.action-buttons {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.sync-status {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.action-buttons button {
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.action-buttons button:hover {
+  background-color: #e0e0e0;
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.html
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ChronicleSync Extension</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.tsx
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/popup.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import '../popup.css';
+
+export function App() {
+  const [initialized, setInitialized] = useState(false);
+  const [clientId, setClientId] = useState('');
+  const [lastSync, setLastSync] = useState<string>('Never');
+  const openHistory = () => {
+    chrome.windows.create({
+      url: chrome.runtime.getURL('history.html'),
+      type: 'popup',
+      width: 500,
+      height: 600
+    });
+  };
+
+  // Load saved state and history when component mounts
+  useEffect(() => {
+    const initializePopup = async () => {
+      try {
+        // Load settings from storage
+        const result = await new Promise<{ clientId?: string; initialized?: boolean; lastSync?: string }>(resolve => {
+          chrome.storage.sync.get(['clientId', 'initialized', 'lastSync'], items => {
+            resolve(items as { clientId?: string; initialized?: boolean; lastSync?: string });
+          });
+        });
+
+        if (result.clientId) {
+          setClientId(result.clientId);
+        }
+        if (result.initialized) {
+          setInitialized(result.initialized);
+        }
+        if (result.lastSync) {
+          const lastSyncDate = new Date(result.lastSync);
+          setLastSync(lastSyncDate.toLocaleString());
+        }
+
+      } catch (error) {
+        console.error('Error initializing popup:', error);
+      }
+    };
+
+    initializePopup();
+
+    // Listen for sync updates from background script
+    const messageListener = (message: { type: string; success?: boolean; lastSync?: string }) => {
+      if (message.type === 'syncComplete') {
+        if (message.lastSync) {
+          setLastSync(message.lastSync);
+        } else {
+          setLastSync(new Date().toLocaleString());
+        }
+      }
+    };
+    chrome.runtime.onMessage.addListener(messageListener);
+    
+    // Cleanup listener when component unmounts
+    return () => {
+      chrome.runtime.onMessage.removeListener(messageListener);
+    };
+  }, []);
+
+  const handleInitialize = () => {
+    if (clientId) {
+      // Save both clientId and initialized state
+      chrome.storage.sync.set({
+        clientId: clientId,
+        initialized: true
+      }, () => {
+        setInitialized(true);
+      });
+    }
+  };
+
+  const handleClientIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newClientId = e.target.value;
+    setClientId(newClientId);
+    // Save clientId as it changes
+    chrome.storage.sync.set({ clientId: newClientId }, () => {});
+  };
+
+  const handleSync = () => {
+    // Send message to background script to trigger sync
+    chrome.runtime.sendMessage({ type: 'triggerSync' }, (response) => {
+      if (chrome.runtime.lastError) {
+        alert('Sync failed: ' + chrome.runtime.lastError.message);
+      } else if (response && response.error) {
+        alert('Sync failed: ' + response.error);
+      } else if (response && response.success) {
+        alert(response.message || 'Sync successful');
+      } else {
+        alert('Sync initiated');
+      }
+    });
+  };
+
+  const openSettings = () => {
+    chrome.runtime.openOptionsPage();
+  };
+
+  return (
+    <div className="app">
+      <h1>ChronicleSync</h1>
+      <div id="adminLogin">
+        <h2>Admin Login</h2>
+        <form>
+          <input
+            type="text"
+            id="clientId"
+            placeholder="Client ID"
+            value={clientId}
+            onChange={handleClientIdChange}
+          />
+          {!initialized ? (
+            <button type="button" onClick={handleInitialize}>Initialize</button>
+          ) : (
+            <button type="button" onClick={handleSync}>Sync with Server</button>
+          )}
+        </form>
+      </div>
+      <div id="status" className="sync-status">
+        Last sync: {lastSync}
+      </div>
+      <div className="action-buttons">
+        <button type="button" onClick={openHistory}>View History</button>
+        <button type="button" onClick={openSettings}>Settings</button>
+      </div>
+    </div>
+  );
+}
+
+// Only mount if we're in a browser environment
+if (typeof document !== 'undefined') {
+  const root = document.getElementById('root');
+  if (root) {
+    ReactDOM.createRoot(root).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+  }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings.css
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings.css
@@ -1,0 +1,187 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.settings-container {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    color: #333;
+    margin-bottom: 30px;
+    text-align: center;
+}
+
+.settings-section {
+    margin-bottom: 30px;
+}
+
+h2 {
+    color: #666;
+    font-size: 1.2em;
+    margin-bottom: 20px;
+}
+
+.setting-item {
+    margin-bottom: 20px;
+}
+
+label {
+    display: block;
+    margin-bottom: 8px;
+    color: #555;
+    font-weight: 500;
+}
+
+input[type="text"],
+input[type="url"],
+select,
+textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+    background-color: white;
+    box-sizing: border-box;
+}
+
+input[type="text"]:focus,
+input[type="url"]:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: #4CAF50;
+    box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
+}
+
+.help-text {
+    display: block;
+    margin-top: 4px;
+    color: #666;
+    font-size: 12px;
+    font-style: italic;
+}
+
+.settings-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 30px;
+    gap: 10px;
+}
+
+button {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s ease;
+    flex: 1;
+}
+
+.primary-button {
+    background-color: #4CAF50;
+    color: white;
+}
+
+.primary-button:hover {
+    background-color: #45a049;
+    transform: translateY(-1px);
+}
+
+.reset-settings {
+    background-color: #f44336;
+    color: white;
+}
+
+.reset-settings:hover {
+    background-color: #da190b;
+    transform: translateY(-1px);
+}
+
+.status-message {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 12px 24px;
+    border-radius: 4px;
+    color: white;
+    text-align: center;
+    animation: slideUp 0.3s ease-out;
+    z-index: 1000;
+}
+
+.status-message.success {
+    background-color: #4CAF50;
+}
+
+.status-message.error {
+    background-color: #f44336;
+}
+
+@keyframes slideUp {
+    from {
+        transform: translate(-50%, 100%);
+        opacity: 0;
+    }
+    to {
+        transform: translate(-50%, 0);
+        opacity: 1;
+    }
+}
+
+#customUrlContainer {
+    transition: all 0.3s ease;
+    overflow: hidden;
+    opacity: 1;
+}
+
+#customUrlContainer[style*="display: none"] {
+    opacity: 0;
+    margin-top: -20px;
+}
+
+.mnemonic-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.secondary-button {
+    background-color: #757575;
+    color: white;
+    padding: 8px 16px;
+    font-size: 13px;
+}
+
+.secondary-button:hover {
+    background-color: #616161;
+    transform: translateY(-1px);
+}
+
+#mnemonic {
+    font-family: monospace;
+    resize: none;
+    line-height: 1.5;
+}
+
+#mnemonic.hidden {
+    -webkit-text-security: disc;
+    text-security: disc;
+}
+
+#clientId {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings.html
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ChronicleSync Settings</title>
+    <link rel="stylesheet" type="text/css" href="settings.css">
+</head>
+<body>
+    <div class="settings-container">
+        <h1>ChronicleSync Settings</h1>
+        
+        <section class="settings-section">
+            <h2>Configuration</h2>
+            <div id="mnemonicContainer" class="setting-item">
+                <label for="mnemonic">Mnemonic Phrase:</label>
+                <textarea id="mnemonic" placeholder="Enter your 24-word mnemonic phrase" rows="3" required></textarea>
+                <div class="mnemonic-actions">
+                    <button id="generateMnemonic" class="secondary-button">Generate New</button>
+                    <button id="showMnemonic" class="secondary-button">Show/Hide</button>
+                </div>
+                <small class="help-text">Your mnemonic phrase is used to generate your unique client ID. Keep it safe!</small>
+            </div>
+            <div class="setting-item">
+                <label for="clientId">Client ID:</label>
+                <input type="text" id="clientId" placeholder="Generated from mnemonic" readonly>
+            </div>
+            <div class="setting-item">
+                <label for="environment">Environment:</label>
+                <select id="environment" required>
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div id="customUrlContainer" class="setting-item" style="display: none;">
+                <label for="customApiUrl">Custom API URL:</label>
+                <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
+                <small class="help-text">Only used when Environment is set to Custom</small>
+            </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
+        </section>
+
+        <div class="settings-actions">
+            <button id="saveSettings" class="primary-button">Save Settings</button>
+            <button id="resetSettings" class="reset-settings">Reset to Default</button>
+        </div>
+    </div>
+    <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings/Settings.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings/Settings.ts
@@ -1,0 +1,252 @@
+interface SettingsConfig {
+  mnemonic: string;
+  clientId: string;
+  customApiUrl: string | null;
+  environment: 'production' | 'staging' | 'custom';
+  expirationDays: number;
+}
+
+type StorageKeys = keyof SettingsConfig;
+
+export class Settings {
+  config: SettingsConfig | null = null;
+  private readonly PROD_API_URL = 'https://api.chroniclesync.xyz';
+  private readonly STAGING_API_URL = 'https://api-staging.chroniclesync.xyz';
+  private bip39WordList: string[] | null = null;
+
+  private readonly DEFAULT_SETTINGS: SettingsConfig = {
+    mnemonic: '',
+    clientId: '',
+    customApiUrl: null,
+    environment: 'production',
+    expirationDays: 7
+  };
+
+  async init(): Promise<void> {
+    try {
+      const { wordList } = await import('../../bip39-wordlist.js');
+      this.bip39WordList = wordList;
+    } catch (error) {
+      console.error('Error loading wordlist:', error);
+      return;
+    }
+
+    const result = await this.getStorageData();
+    this.config = {
+      mnemonic: result.mnemonic || this.DEFAULT_SETTINGS.mnemonic,
+      clientId: result.clientId || this.DEFAULT_SETTINGS.clientId,
+      customApiUrl: result.customApiUrl || this.DEFAULT_SETTINGS.customApiUrl,
+      environment: result.environment || this.DEFAULT_SETTINGS.environment,
+      expirationDays: result.expirationDays || this.DEFAULT_SETTINGS.expirationDays
+    };
+
+    // Generate initial mnemonic if needed
+    if (!this.config.mnemonic || !this.config.clientId) {
+      const mnemonic = this.generateMnemonic();
+      if (mnemonic) {
+        const clientId = await this.generateClientId(mnemonic);
+        this.config = {
+          ...this.config,
+          mnemonic,
+          clientId
+        };
+        await this.handleSave();
+      }
+    }
+
+    this.render();
+    this.setupEventListeners();
+  }
+
+  private generateMnemonic(): string | null {
+    if (!this.bip39WordList) return null;
+    const entropy = new Uint8Array(32);
+    crypto.getRandomValues(entropy);
+    const words = [];
+    for (let i = 0; i < 24; i++) {
+      const index = Math.floor((entropy[i] / 256) * this.bip39WordList.length);
+      words.push(this.bip39WordList[index]);
+    }
+    return words.join(' ');
+  }
+
+  private validateMnemonic(mnemonic: string): boolean {
+    if (!this.bip39WordList) return false;
+    const words = mnemonic.trim().toLowerCase().split(/\s+/);
+    if (words.length !== 24) return false;
+    return words.every(word => this.bip39WordList!.includes(word));
+  }
+
+  private async generateClientId(mnemonic: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(mnemonic);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hash));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  private async getStorageData(): Promise<Partial<SettingsConfig>> {
+    return new Promise((resolve) => {
+      const keys: StorageKeys[] = ['mnemonic', 'clientId', 'customApiUrl', 'environment', 'expirationDays'];
+      chrome.storage.sync.get(keys, (result) => resolve(result as Partial<SettingsConfig>));
+    });
+  }
+
+  getApiUrl(): string {
+    if (!this.config) throw new Error('Settings not initialized');
+    
+    switch (this.config.environment) {
+    case 'production':
+      return this.PROD_API_URL;
+    case 'staging':
+      return this.STAGING_API_URL;
+    case 'custom':
+      return this.config.customApiUrl || this.PROD_API_URL;
+    default:
+      return this.PROD_API_URL;
+    }
+  }
+
+  private render(): void {
+    if (!this.config) return;
+
+    const mnemonicInput = document.getElementById('mnemonic') as HTMLTextAreaElement;
+    const clientIdInput = document.getElementById('clientId') as HTMLInputElement;
+    const environmentSelect = document.getElementById('environment') as HTMLSelectElement;
+    const customUrlContainer = document.getElementById('customUrlContainer') as HTMLDivElement;
+    const customApiUrlInput = document.getElementById('customApiUrl') as HTMLInputElement;
+    const expirationDaysInput = document.getElementById('expirationDays') as HTMLInputElement;
+
+    mnemonicInput.value = this.config.mnemonic;
+    clientIdInput.value = this.config.clientId;
+    environmentSelect.value = this.config.environment;
+    customApiUrlInput.value = this.config.customApiUrl || '';
+    expirationDaysInput.value = this.config.expirationDays.toString();
+    
+    customUrlContainer.style.display = this.config.environment === 'custom' ? 'block' : 'none';
+  }
+
+  private setupEventListeners(): void {
+    document.getElementById('saveSettings')?.addEventListener('click', (e) => this.handleSave(e));
+    document.getElementById('resetSettings')?.addEventListener('click', () => this.handleReset());
+    document.getElementById('environment')?.addEventListener('change', () => this.handleEnvironmentChange());
+    document.getElementById('generateMnemonic')?.addEventListener('click', () => this.handleGenerateMnemonic());
+    document.getElementById('showMnemonic')?.addEventListener('click', () => this.handleShowMnemonic());
+    document.getElementById('mnemonic')?.addEventListener('input', () => this.handleMnemonicInput());
+  }
+
+  private async handleMnemonicInput(): Promise<void> {
+    const mnemonicInput = document.getElementById('mnemonic') as HTMLTextAreaElement;
+    const clientIdInput = document.getElementById('clientId') as HTMLInputElement;
+    if (!mnemonicInput || !clientIdInput) return;
+
+    const mnemonic = mnemonicInput.value.trim();
+    if (this.validateMnemonic(mnemonic)) {
+      const clientId = await this.generateClientId(mnemonic);
+      clientIdInput.value = clientId;
+      this.config = {
+        ...this.config!,
+        mnemonic,
+        clientId
+      };
+    } else {
+      clientIdInput.value = '';
+    }
+  }
+
+  private handleShowMnemonic(): void {
+    const mnemonicInput = document.getElementById('mnemonic') as HTMLTextAreaElement;
+    if (!mnemonicInput) return;
+    mnemonicInput.classList.toggle('hidden');
+  }
+
+  private async handleGenerateMnemonic(): Promise<void> {
+    const mnemonicInput = document.getElementById('mnemonic') as HTMLTextAreaElement;
+    if (!mnemonicInput) return;
+
+    const mnemonic = this.generateMnemonic();
+    if (mnemonic) {
+      mnemonicInput.value = mnemonic;
+      await this.handleMnemonicInput();
+      await this.handleSave();
+    }
+  }
+
+  private handleEnvironmentChange(): void {
+    const environmentSelect = document.getElementById('environment') as HTMLSelectElement;
+    const customUrlContainer = document.getElementById('customUrlContainer') as HTMLDivElement;
+    customUrlContainer.style.display = environmentSelect.value === 'custom' ? 'block' : 'none';
+  }
+
+  private async handleSave(event?: Event): Promise<void> {
+    event?.preventDefault();
+
+    const mnemonicInput = document.getElementById('mnemonic') as HTMLTextAreaElement;
+    const clientIdInput = document.getElementById('clientId') as HTMLInputElement;
+    const environmentSelect = document.getElementById('environment') as HTMLSelectElement;
+    const customApiUrlInput = document.getElementById('customApiUrl') as HTMLInputElement;
+    const expirationDaysInput = document.getElementById('expirationDays') as HTMLInputElement;
+
+    const mnemonic = mnemonicInput.value.trim();
+    if (!this.validateMnemonic(mnemonic)) {
+      this.showMessage('Please enter a valid 24-word mnemonic phrase', 'error');
+      return;
+    }
+
+    const expirationDays = parseInt(expirationDaysInput.value);
+    if (isNaN(expirationDays) || expirationDays < 1) {
+      this.showMessage('Please enter a valid number of days for expiration (minimum 1)', 'error');
+      return;
+    }
+
+    const clientId = await this.generateClientId(mnemonic);
+    clientIdInput.value = clientId;
+
+    const newConfig: SettingsConfig = {
+      mnemonic,
+      clientId,
+      environment: environmentSelect.value as SettingsConfig['environment'],
+      customApiUrl: environmentSelect.value === 'custom' ? customApiUrlInput.value.trim() : null,
+      expirationDays
+    };
+
+    if (newConfig.environment === 'custom' && !newConfig.customApiUrl) {
+      this.showMessage('Custom API URL is required when using custom environment', 'error');
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      chrome.storage.sync.set(newConfig, () => resolve());
+    });
+
+    this.config = newConfig;
+    this.showMessage('Settings saved successfully!', 'success');
+  }
+
+  private async handleReset(): Promise<void> {
+    if (confirm('Are you sure you want to reset all settings to default values?')) {
+      const mnemonic = this.generateMnemonic();
+      if (mnemonic) {
+        const clientId = await this.generateClientId(mnemonic);
+        this.config = {
+          ...this.DEFAULT_SETTINGS,
+          mnemonic,
+          clientId
+        };
+        this.render();
+        await this.handleSave();
+      }
+    }
+  }
+
+  private showMessage(text: string, type: 'success' | 'error'): void {
+    const status = document.createElement('div');
+    status.className = `status-message ${type}`;
+    status.textContent = text;
+    document.querySelector('.settings-actions')?.appendChild(status);
+
+    setTimeout(() => {
+      status.remove();
+    }, 3000);
+  }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings/index.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/settings/index.ts
@@ -1,0 +1,6 @@
+import { Settings } from './Settings';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const settings = new Settings();
+  settings.init().catch(console.error);
+});

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/types.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/types.ts
@@ -1,0 +1,48 @@
+export interface DeviceInfo {
+  deviceId: string;
+  platform: string;
+  userAgent: string;
+  browserName: string;
+  browserVersion: string;
+}
+
+export interface PageContent {
+  content: string;
+  summary: string;
+  extractedAt: number;
+}
+
+export interface HistoryEntry {
+  url: string;
+  title: string;
+  visitTime: number;
+  visitId: string;
+  referringVisitId: string;
+  transition: string;
+  deviceId: string;
+  platform: string;
+  userAgent: string;
+  browserName: string;
+  browserVersion: string;
+  syncStatus: 'pending' | 'synced';
+  lastModified: number;
+  deleted?: boolean;
+  pageContent?: PageContent;
+}
+
+export interface SyncResponse {
+  history: HistoryEntry[];
+  lastSyncTime: number;
+  devices: DeviceInfo[];
+}
+
+export interface SearchResult {
+  visitId: string;
+  url: string;
+  title: string;
+  visitTime: number;
+  matches: {
+    text: string;
+    context: string;
+  }[];
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/utils/content-extractor.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/utils/content-extractor.ts
@@ -1,0 +1,154 @@
+// Utility to extract and summarize webpage content
+
+interface PageContent {
+  content: string;
+  summary: string;
+}
+
+/**
+ * Extract the main content from the current webpage
+ * @returns Object containing the extracted content and a summary
+ */
+export function extractPageContent(): PageContent {
+  // Extract the main content from the page
+  const content = extractMainContent();
+  
+  // Generate a summary of the content
+  const summary = generateSummary(content);
+  
+  return {
+    content,
+    summary
+  };
+}
+
+/**
+ * Extract the main content from the webpage
+ * Prioritizes article content, main elements, and readable text
+ */
+function extractMainContent(): string {
+  // Try to find the main content container
+  const contentSelectors = [
+    'article',
+    '[role="main"]',
+    'main',
+    '.main-content',
+    '#content',
+    '.content',
+    '.post-content',
+    '.article-content'
+  ];
+  
+  let mainContent = '';
+  
+  // Try each selector to find the main content
+  for (const selector of contentSelectors) {
+    const elements = document.querySelectorAll(selector);
+    if (elements.length > 0) {
+      // Use the element with the most text content
+      let bestElement = elements[0];
+      let maxLength = bestElement.textContent?.length || 0;
+      
+      for (let i = 1; i < elements.length; i++) {
+        const length = elements[i].textContent?.length || 0;
+        if (length > maxLength) {
+          maxLength = length;
+          bestElement = elements[i];
+        }
+      }
+      
+      mainContent = bestElement.textContent || '';
+      if (mainContent.length > 200) {
+        break;
+      }
+    }
+  }
+  
+  // If no main content found, extract from body
+  if (mainContent.length < 200) {
+    // Get all paragraphs
+    const paragraphs = document.querySelectorAll('p');
+    const paragraphTexts: string[] = [];
+    
+    paragraphs.forEach(p => {
+      const text = p.textContent?.trim() || '';
+      if (text.length > 20) { // Only include substantial paragraphs
+        paragraphTexts.push(text);
+      }
+    });
+    
+    mainContent = paragraphTexts.join('\n\n');
+  }
+  
+  // If still no good content, get all text from body
+  if (mainContent.length < 200) {
+    mainContent = document.body.textContent || '';
+  }
+  
+  // Clean up the content
+  return cleanContent(mainContent);
+}
+
+/**
+ * Clean up extracted content
+ */
+function cleanContent(content: string): string {
+  return content
+    .replace(/\\s+/g, ' ')
+    .replace(/\\n+/g, '\n')
+    .trim();
+}
+
+/**
+ * Generate a summary of the content
+ * Uses a simple algorithm to extract key sentences
+ */
+function generateSummary(content: string): string {
+  if (!content || content.length < 100) {
+    return content;
+  }
+  
+  // Split content into sentences
+  const sentences = content
+    .replace(/([.!?])\\s*(?=[A-Z])/g, '$1|')
+    .split('|')
+    .filter(s => s.trim().length > 10);
+  
+  if (sentences.length <= 3) {
+    return sentences.join(' ');
+  }
+  
+  // Calculate word frequency
+  const wordFrequency: Record<string, number> = {};
+  const words = content.toLowerCase().match(/\\b\\w{3,}\\b/g) || [];
+  
+  words.forEach(word => {
+    wordFrequency[word] = (wordFrequency[word] || 0) + 1;
+  });
+  
+  // Score sentences based on word frequency
+  const sentenceScores = sentences.map(sentence => {
+    const sentenceWords = sentence.toLowerCase().match(/\\b\\w{3,}\\b/g) || [];
+    let score = 0;
+    
+    sentenceWords.forEach(word => {
+      if (wordFrequency[word]) {
+        score += wordFrequency[word];
+      }
+    });
+    
+    return {
+      sentence,
+      score: score / Math.max(1, sentenceWords.length)
+    };
+  });
+  
+  // Sort sentences by score and take top 3
+  const topSentences = sentenceScores
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map(item => item.sentence);
+  
+  // Return summary
+  return topSentences.join(' ');
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/utils/system.ts
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/Resources/utils/system.ts
@@ -1,0 +1,27 @@
+import { DeviceInfo } from '../types';
+
+export async function getDeviceId(): Promise<string> {
+  const result = await chrome.storage.local.get(['deviceId']);
+  if (result.deviceId) {
+    return result.deviceId;
+  }
+  const deviceId = 'device_' + Math.random().toString(36).substring(2);
+  await chrome.storage.local.set({ deviceId });
+  return deviceId;
+}
+
+export async function getSystemInfo(): Promise<DeviceInfo> {
+  const platform = navigator.platform;
+  const userAgent = navigator.userAgent;
+  const deviceId = await getDeviceId();
+  const browserName = 'Chrome';
+  const browserVersion = /Chrome\/([0-9.]+)/.exec(userAgent)?.[1] || 'unknown';
+
+  return {
+    deviceId,
+    platform,
+    userAgent,
+    browserName,
+    browserVersion
+  };
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari-Extension/SafariWebExtensionHandler.swift
+++ b/ChronicleSync-Safari/ChronicleSync-Safari-Extension/SafariWebExtensionHandler.swift
@@ -1,0 +1,19 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+
+    let logger = Logger(subsystem: "xyz.chroniclesync.ChronicleSync-Safari.Extension", category: "Extension")
+    
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as? NSExtensionItem
+        let message = item?.userInfo?[SFExtensionMessageKey]
+        
+        logger.log("Received message from browser.runtime.sendNativeMessage: \(String(describing: message))")
+        
+        let response = NSExtensionItem()
+        response.userInfo = [ SFExtensionMessageKey: [ "Response": "Received message from Safari App Extension" ] ]
+        
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari.xcodeproj/project.pbxproj
+++ b/ChronicleSync-Safari/ChronicleSync-Safari.xcodeproj/project.pbxproj
@@ -1,0 +1,657 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1A1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */; };
+		1A1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */; };
+		1A1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */; };
+		1A1A1A1A1A1A1A1A1A1A1A28 /* ChronicleSync-Safari-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A29 /* ChronicleSync-Safari-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1A1A1A1A1A1A1A1A1A1A1A2A /* ChronicleSync-SafariTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1A1A1A1A1A1A1A1A1A1A2B /* ChronicleSync-SafariTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1A1A1A1A1A1A1A1A1A1A1A2C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A1A1A1A1A1A1A1A1A1A1A2D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A1A1A1A1A1A1A1A1A1A1A2E;
+			remoteInfo = "ChronicleSync-Safari";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A2F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A1A1A1A1A1A1A1A1A1A1A2D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A1A1A1A1A1A1A1A1A1A1A30;
+			remoteInfo = "ChronicleSync-Safari-Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A31 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1A28 /* ChronicleSync-Safari-Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		1A1A1A1A1A1A1A1A1A1A1A32 /* ChronicleSync-Safari.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ChronicleSync-Safari.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A33 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A34 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A35 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A29 /* ChronicleSync-Safari-Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ChronicleSync-Safari-Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A36 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebExtensionHandler.swift; sourceTree = "<group>"; };
+		1A1A1A1A1A1A1A1A1A1A37 /* ChronicleSync-SafariTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ChronicleSync-SafariTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A1A1A1A1A1A1A1A1A1A2B /* ChronicleSync-SafariTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChronicleSync-SafariTests.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A38 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A39 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A1A1A1A1A1A1A1A1A1A1A3B = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1A3C /* ChronicleSync-Safari */,
+				1A1A1A1A1A1A1A1A1A1A1A3D /* ChronicleSync-Safari-Extension */,
+				1A1A1A1A1A1A1A1A1A1A1A3E /* ChronicleSync-SafariTests */,
+				1A1A1A1A1A1A1A1A1A1A1A3F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A3F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A32 /* ChronicleSync-Safari.app */,
+				1A1A1A1A1A1A1A1A1A1A29 /* ChronicleSync-Safari-Extension.appex */,
+				1A1A1A1A1A1A1A1A1A1A37 /* ChronicleSync-SafariTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A3C /* ChronicleSync-Safari */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A1B /* AppDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1D /* SceneDelegate.swift */,
+				1A1A1A1A1A1A1A1A1A1A1F /* ViewController.swift */,
+				1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A23 /* Assets.xcassets */,
+				1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */,
+				1A1A1A1A1A1A1A1A1A1A35 /* Info.plist */,
+			);
+			path = "ChronicleSync-Safari";
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A3D /* ChronicleSync-Safari-Extension */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A27 /* SafariWebExtensionHandler.swift */,
+				1A1A1A1A1A1A1A1A1A1A36 /* Info.plist */,
+				1A1A1A1A1A1A1A1A1A1A40 /* Resources */,
+			);
+			path = "ChronicleSync-Safari-Extension";
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A40 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A3E /* ChronicleSync-SafariTests */ = {
+			isa = PBXGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A2B /* ChronicleSync-SafariTests.swift */,
+			);
+			path = "ChronicleSync-SafariTests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A1A1A1A1A1A1A1A1A1A1A2E /* ChronicleSync-Safari */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A41 /* Build configuration list for PBXNativeTarget "ChronicleSync-Safari" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A38 /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A42 /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A43 /* Resources */,
+				1A1A1A1A1A1A1A1A1A1A31 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A1A1A1A1A1A1A1A1A1A1A44 /* PBXTargetDependency */,
+			);
+			name = "ChronicleSync-Safari";
+			productName = "ChronicleSync-Safari";
+			productReference = 1A1A1A1A1A1A1A1A1A1A32 /* ChronicleSync-Safari.app */;
+			productType = "com.apple.product-type.application";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A30 /* ChronicleSync-Safari-Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A45 /* Build configuration list for PBXNativeTarget "ChronicleSync-Safari-Extension" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A39 /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A46 /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A47 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ChronicleSync-Safari-Extension";
+			productName = "ChronicleSync-Safari-Extension";
+			productReference = 1A1A1A1A1A1A1A1A1A1A29 /* ChronicleSync-Safari-Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		1A1A1A1A1A1A1A1A1A1A1A48 /* ChronicleSync-SafariTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A49 /* Build configuration list for PBXNativeTarget "ChronicleSync-SafariTests" */;
+			buildPhases = (
+				1A1A1A1A1A1A1A1A1A1A1A3A /* Frameworks */,
+				1A1A1A1A1A1A1A1A1A1A1A4A /* Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A4B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A1A1A1A1A1A1A1A1A1A1A4C /* PBXTargetDependency */,
+			);
+			name = "ChronicleSync-SafariTests";
+			productName = "ChronicleSync-SafariTests";
+			productReference = 1A1A1A1A1A1A1A1A1A1A37 /* ChronicleSync-SafariTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A1A1A1A1A1A1A1A1A1A1A2D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					1A1A1A1A1A1A1A1A1A1A1A2E = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					1A1A1A1A1A1A1A1A1A1A1A30 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					1A1A1A1A1A1A1A1A1A1A1A48 = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 1A1A1A1A1A1A1A1A1A1A1A2E;
+					};
+				};
+			};
+			buildConfigurationList = 1A1A1A1A1A1A1A1A1A1A1A4D /* Build configuration list for PBXProject "ChronicleSync-Safari" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A1A1A1A1A1A1A1A1A1A1A3B;
+			productRefGroup = 1A1A1A1A1A1A1A1A1A1A1A3F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A1A1A1A1A1A1A1A1A1A1A2E /* ChronicleSync-Safari */,
+				1A1A1A1A1A1A1A1A1A1A1A30 /* ChronicleSync-Safari-Extension */,
+				1A1A1A1A1A1A1A1A1A1A1A48 /* ChronicleSync-SafariTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A43 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A24 /* LaunchScreen.storyboard in Resources */,
+				1A1A1A1A1A1A1A1A1A1A22 /* Assets.xcassets in Resources */,
+				1A1A1A1A1A1A1A1A1A1A20 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A47 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A1A1A1A1A1A1A1A1A1A1A42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A1E /* ViewController.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1A /* AppDelegate.swift in Sources */,
+				1A1A1A1A1A1A1A1A1A1A1C /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A46 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A26 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A1A1A1A1A1A1A1A1A1A2A /* ChronicleSync-SafariTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A1A1A1A1A1A1A1A1A1A1A44 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A1A1A1A1A1A1A1A1A1A1A30 /* ChronicleSync-Safari-Extension */;
+			targetProxy = 1A1A1A1A1A1A1A1A1A1A2F /* PBXContainerItemProxy */;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A1A1A1A1A1A1A1A1A1A1A2E /* ChronicleSync-Safari */;
+			targetProxy = 1A1A1A1A1A1A1A1A1A1A2C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		1A1A1A1A1A1A1A1A1A1A21 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A33 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		1A1A1A1A1A1A1A1A1A1A25 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1A1A1A1A1A1A1A1A1A1A34 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		1A1A1A1A1A1A1A1A1A1A1A4E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A50 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync-Safari/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Safari";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync-Safari/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Safari";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync-Safari-Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync-Safari-Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Safari.Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A53 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ChronicleSync-Safari-Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "ChronicleSync-Safari-Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Safari.Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-SafariTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChronicleSync-Safari.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChronicleSync-Safari";
+			};
+			name = Debug;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A55 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-SafariTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChronicleSync-Safari.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChronicleSync-Safari";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A1A1A1A1A1A1A1A1A1A1A41 /* Build configuration list for PBXNativeTarget "ChronicleSync-Safari" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A50 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A45 /* Build configuration list for PBXNativeTarget "ChronicleSync-Safari-Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A52 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A53 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A49 /* Build configuration list for PBXNativeTarget "ChronicleSync-SafariTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A54 /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A55 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A1A1A1A1A1A1A1A1A1A1A4D /* Build configuration list for PBXProject "ChronicleSync-Safari" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A1A1A1A1A1A1A1A1A1A1A4E /* Debug */,
+				1A1A1A1A1A1A1A1A1A1A1A4F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A1A1A1A1A1A1A1A1A1A1A2D /* Project object */;
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari/AppDelegate.swift
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari/Base.lproj/LaunchScreen.storyboard
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hhg-Vc-Qqu">
+                                <rect key="frame" x="107.33333333333333" y="408.66666666666669" width="178.33333333333337" height="35"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="29"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Hhg-Vc-Qqu" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Hhg-Vc-Qqv"/>
+                            <constraint firstItem="Hhg-Vc-Qqu" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Hhg-Vc-Qqw"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ChronicleSync-Safari/ChronicleSync-Safari/Base.lproj/Main.storyboard
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/Base.lproj/Main.storyboard
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ChronicleSync_Safari" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ygd-Vc-Qqe">
+                                <rect key="frame" x="20" y="359" width="353" height="134.33333333333337"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Hhg-Vc-Qqf">
+                                        <rect key="frame" x="0.0" y="0.0" width="353" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="Hhg-Vc-Qqg"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync Safari Extension" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hhg-Vc-Qqh">
+                                        <rect key="frame" x="0.0" y="70" width="353" height="24"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Extension status loading..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hhg-Vc-Qqi">
+                                        <rect key="frame" x="0.0" y="114" width="353" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hhg-Vc-Qqj">
+                                <rect key="frame" x="96.666666666666686" y="513.33333333333337" width="200" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Hhg-Vc-Qqk"/>
+                                    <constraint firstAttribute="height" constant="50" id="Hhg-Vc-Qql"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Enable Extension"/>
+                                <connections>
+                                    <action selector="openExtensionSettings:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Hhg-Vc-Qqm"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ygd-Vc-Qqe" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" constant="-20" id="Hhg-Vc-Qqn"/>
+                            <constraint firstItem="Hhg-Vc-Qqj" firstAttribute="top" secondItem="Ygd-Vc-Qqe" secondAttribute="bottom" constant="20" id="Hhg-Vc-Qqo"/>
+                            <constraint firstItem="Hhg-Vc-Qqj" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Hhg-Vc-Qqp"/>
+                            <constraint firstItem="Ygd-Vc-Qqe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="Hhg-Vc-Qqq"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Ygd-Vc-Qqe" secondAttribute="trailing" constant="20" id="Hhg-Vc-Qqr"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="enableExtensionButton" destination="Hhg-Vc-Qqj" id="Hhg-Vc-Qqs"/>
+                        <outlet property="statusLabel" destination="Hhg-Vc-Qqi" id="Hhg-Vc-Qqt"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="138" y="4"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ChronicleSync-Safari/ChronicleSync-Safari/Info.plist
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ChronicleSync-Safari/ChronicleSync-Safari/SceneDelegate.swift
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/SceneDelegate.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}

--- a/ChronicleSync-Safari/ChronicleSync-Safari/ViewController.swift
+++ b/ChronicleSync-Safari/ChronicleSync-Safari/ViewController.swift
@@ -1,0 +1,54 @@
+import UIKit
+import SafariServices
+
+class ViewController: UIViewController {
+    
+    @IBOutlet weak var enableExtensionButton: UIButton!
+    @IBOutlet weak var statusLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateExtensionStatus()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateExtensionStatus()
+    }
+    
+    @IBAction func openExtensionSettings(_ sender: Any) {
+        SFSafariApplication.showPreferencesForExtension(withIdentifier: "xyz.chroniclesync.ChronicleSync-Safari.Extension") { error in
+            guard error == nil else {
+                self.showError("Failed to open extension settings: \(error!.localizedDescription)")
+                return
+            }
+        }
+    }
+    
+    private func updateExtensionStatus() {
+        SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: "xyz.chroniclesync.ChronicleSync-Safari.Extension") { [weak self] (state, error) in
+            guard let self = self else { return }
+            
+            DispatchQueue.main.async {
+                if let state = state, error == nil {
+                    if state.isEnabled {
+                        self.statusLabel.text = "ChronicleSync Safari Extension is enabled."
+                        self.enableExtensionButton.setTitle("Extension Settings", for: .normal)
+                    } else {
+                        self.statusLabel.text = "ChronicleSync Safari Extension is disabled. Please enable it in Safari settings."
+                        self.enableExtensionButton.setTitle("Enable Extension", for: .normal)
+                    }
+                } else {
+                    self.statusLabel.text = "Unable to determine extension status."
+                    self.enableExtensionButton.setTitle("Open Safari Settings", for: .normal)
+                }
+            }
+        }
+    }
+    
+    private func showError(_ message: String) {
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}

--- a/ChronicleSync-Safari/ChronicleSync-SafariTests/ChronicleSync-SafariTests.swift
+++ b/ChronicleSync-Safari/ChronicleSync-SafariTests/ChronicleSync-SafariTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import ChronicleSync_Safari
+
+class ChronicleSync_SafariTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testAppInitialization() throws {
+        // Test that the app initializes correctly
+        let app = UIApplication.shared
+        XCTAssertNotNil(app, "App should initialize")
+    }
+    
+    func testViewControllerLoads() throws {
+        // Test that the main view controller loads correctly
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let viewController = storyboard.instantiateInitialViewController() as? ViewController
+        
+        XCTAssertNotNil(viewController, "ViewController should be instantiated from storyboard")
+        
+        // Load the view hierarchy
+        _ = viewController?.view
+        
+        // Check that outlets are connected
+        XCTAssertNotNil(viewController?.enableExtensionButton, "Enable extension button should be connected")
+        XCTAssertNotNil(viewController?.statusLabel, "Status label should be connected")
+    }
+}

--- a/ChronicleSync-Safari/ChronicleSync-SafariUITests/ChronicleSync-SafariUITests.swift
+++ b/ChronicleSync-Safari/ChronicleSync-SafariUITests/ChronicleSync-SafariUITests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+class ChronicleSync_SafariUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it's important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testAppLaunch() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Verify that the app launched successfully
+        XCTAssertTrue(app.buttons["Enable Extension"].exists || app.buttons["Extension Settings"].exists, "Extension button should exist")
+        
+        // Verify that the status label exists
+        XCTAssertTrue(app.staticTexts.element(matching: .any, identifier: "statusLabel").exists, "Status label should exist")
+    }
+    
+    func testExtensionButtonTap() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Tap the extension button
+        if app.buttons["Enable Extension"].exists {
+            app.buttons["Enable Extension"].tap()
+        } else if app.buttons["Extension Settings"].exists {
+            app.buttons["Extension Settings"].tap()
+        } else {
+            XCTFail("Extension button not found")
+        }
+        
+        // Since this would open Safari settings, we can't verify much more in a UI test
+        // Just verify the app is still running
+        XCTAssertTrue(app.exists, "App should still be running after button tap")
+    }
+}

--- a/ChronicleSync-Safari/README.md
+++ b/ChronicleSync-Safari/README.md
@@ -1,0 +1,56 @@
+# ChronicleSync Safari Extension
+
+This is the iOS Safari extension version of the ChronicleSync Chrome extension. It allows you to use ChronicleSync functionality in Safari on iOS devices.
+
+## Features
+
+- Integrates with the existing ChronicleSync functionality
+- Provides a native iOS app for managing the extension
+- Supports all the same features as the Chrome extension
+
+## Development
+
+### Prerequisites
+
+- Xcode 14.0 or later
+- iOS 15.0 or later
+- macOS 12.0 or later (for development)
+
+### Building the Project
+
+1. Open the `ChronicleSync-Safari.xcodeproj` file in Xcode
+2. Select your development team in the Signing & Capabilities tab
+3. Build and run the project on your device or simulator
+
+### Testing
+
+The project includes unit tests and UI tests:
+
+- Run unit tests with `⌘+U` in Xcode
+- UI tests can be run individually from the Test navigator
+
+## Architecture
+
+The Safari extension consists of:
+
+1. A native iOS app that serves as a container for the extension
+2. A Safari Web Extension that contains the adapted Chrome extension code
+3. A communication layer between the native app and the extension
+
+## Deployment
+
+The project includes a GitHub Actions workflow that:
+
+1. Builds the project
+2. Runs tests
+3. Creates an unsigned IPA file for distribution
+
+To create a signed IPA for App Store distribution, you'll need to:
+
+1. Configure the appropriate certificates and provisioning profiles
+2. Update the build settings in Xcode
+3. Use Xcode's Archive functionality to create a signed IPA
+
+## License
+
+Same as the main ChronicleSync project.

--- a/ChronicleSync-Safari/build.sh
+++ b/ChronicleSync-Safari/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Build script for ChronicleSync Safari Extension
+# This script builds the Safari extension and creates an unsigned IPA
+
+# Exit on error
+set -e
+
+# Set up variables
+PROJECT_NAME="ChronicleSync-Safari"
+SCHEME_NAME="ChronicleSync-Safari"
+BUILD_DIR="build"
+ARCHIVE_PATH="${BUILD_DIR}/${PROJECT_NAME}.xcarchive"
+IPA_PATH="${BUILD_DIR}/${PROJECT_NAME}.ipa"
+
+# Create build directory if it doesn't exist
+mkdir -p "${BUILD_DIR}"
+
+# Clean previous builds
+echo "Cleaning previous builds..."
+xcodebuild clean -project "${PROJECT_NAME}.xcodeproj" -scheme "${SCHEME_NAME}" || true
+
+# Build the project
+echo "Building project..."
+xcodebuild build -project "${PROJECT_NAME}.xcodeproj" -scheme "${SCHEME_NAME}" -destination "generic/platform=iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+# Run tests
+echo "Running tests..."
+xcodebuild test -project "${PROJECT_NAME}.xcodeproj" -scheme "${SCHEME_NAME}" -destination "platform=iOS Simulator,name=iPhone 14" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+# Create archive
+echo "Creating archive..."
+xcodebuild archive -project "${PROJECT_NAME}.xcodeproj" -scheme "${SCHEME_NAME}" -archivePath "${ARCHIVE_PATH}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+# Create IPA
+echo "Creating IPA..."
+mkdir -p "${BUILD_DIR}/Payload"
+cp -r "${ARCHIVE_PATH}/Products/Applications/${PROJECT_NAME}.app" "${BUILD_DIR}/Payload/"
+(cd "${BUILD_DIR}" && zip -r "${PROJECT_NAME}.ipa" "Payload")
+
+# Clean up
+rm -rf "${BUILD_DIR}/Payload"
+
+echo "Build completed successfully!"
+echo "Archive: ${ARCHIVE_PATH}"
+echo "IPA: ${IPA_PATH}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sync stuff across browsers
 
 - **Offline-First**: Continue working without internet connection with automatic background sync
 - **Not Secure**: I'm to lazy and the models suck too much for local encryption, but it's coming.
-- **Not Multiplatform**: We haven't added IOS support cause basic stuff still doesn't work.
+- **Multiplatform**: Now with iOS Safari extension support!
 - **Real-time Monitoring**: Health monitoring and administrative dashboard
 
 ## Quick Start
@@ -18,6 +18,7 @@ Sync stuff across browsers
 
 ### Developer Documentation
 - [Extension Developer Guide](extension/DEVELOPER.md) - Detailed guide for Chrome extension development
+- [Safari Extension Developer Guide](ChronicleSync-Safari/README.md) - Guide for iOS Safari extension development
 - [Web Application Developer Guide](pages/DEVELOPER.md) - Complete documentation for the React web application
 - [Worker Developer Guide](worker/DEVELOPER.md) - Comprehensive guide for the Cloudflare Worker backend
 
@@ -25,7 +26,8 @@ Sync stuff across browsers
 
 ```
 chroniclesync/
-├── pages/          # Frontend React application
-├── extension/      # Chrome extension
-└── worker/         # Cloudflare Worker backend
+├── pages/                  # Frontend React application
+├── extension/              # Chrome extension
+├── ChronicleSync-Safari/   # iOS Safari extension
+└── worker/                 # Cloudflare Worker backend
 ```


### PR DESCRIPTION
This PR adds an iOS Safari extension that wraps the existing Chrome extension code. It includes:

- A native iOS app container for the Safari extension
- Safari extension that reuses the Chrome extension code
- Native iOS tests for basic functionality
- GitHub Action workflow for building, testing, and creating an unsigned IPA

The Safari extension maintains feature parity with the Chrome extension by reusing the same core code.