### PR TITLE
Add Safari iOS extension

### DIFF
--- a/.github/workflows/safari-extension-test.yml
+++ b/.github/workflows/safari-extension-test.yml
@@ -1,0 +1,38 @@
+name: Safari Extension Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'extension/safari/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'extension/safari/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test Safari Extension
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      
+      - name: Build and Test
+        run: |
+          cd extension/safari/ChronicleSync
+          xcodebuild test -scheme ChronicleSync -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' | xcpretty
+      
+      - name: Upload Test Screenshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-screenshots
+          path: ~/Library/Developer/Xcode/DerivedData/*/Logs/Test/*.xcresult/Attachments/**/*.png
+          if-no-files-found: ignore

--- a/extension/safari/ChronicleSync/ChronicleSync Tests/ChronicleSync_Tests.swift
+++ b/extension/safari/ChronicleSync/ChronicleSync Tests/ChronicleSync_Tests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import SafariServices
+@testable import ChronicleSync
+
+final class ChronicleSync_Tests: XCTestCase {
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        continueAfterFailure = false
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testAppLaunch() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Verify the app launched successfully
+        XCTAssertTrue(app.isRunning)
+        
+        // Take a screenshot of the main screen
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.lifetime = .keepAlways
+        attachment.name = "App Launch Screen"
+        add(attachment)
+        
+        // Verify main UI elements are present
+        XCTAssertTrue(app.staticTexts["ChronicleSync"].exists)
+        XCTAssertTrue(app.buttons["Enable Safari Extension"].exists)
+        XCTAssertTrue(app.buttons["Open Settings"].exists)
+    }
+    
+    func testSettingsButton() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Tap the Settings button
+        app.buttons["Open Settings"].tap()
+        
+        // Take a screenshot after tapping settings
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.lifetime = .keepAlways
+        attachment.name = "Settings Screen"
+        add(attachment)
+        
+        // Since this would open Safari, we can't easily verify the result in this test
+        // In a real test, we would need to handle the app switching
+    }
+    
+    func testExtensionEnableButton() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        // Tap the Enable Extension button
+        app.buttons["Enable Safari Extension"].tap()
+        
+        // Take a screenshot after tapping enable extension
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.lifetime = .keepAlways
+        attachment.name = "Extension Enable Screen"
+        add(attachment)
+        
+        // Since this would open Settings, we can't easily verify the result in this test
+        // In a real test, we would need to handle the app switching
+    }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync.xcodeproj/project.pbxproj
+++ b/extension/safari/ChronicleSync/ChronicleSync.xcodeproj/project.pbxproj
@@ -1,0 +1,541 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1A2B3C4D5E6F7890ABCDEF01 /* SafariWebExtensionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF02 /* SafariWebExtensionHandler.swift */; };
+		1A2B3C4D5E6F7890ABCDEF03 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF04 /* AppDelegate.swift */; };
+		1A2B3C4D5E6F7890ABCDEF05 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF06 /* SceneDelegate.swift */; };
+		1A2B3C4D5E6F7890ABCDEF07 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF08 /* ViewController.swift */; };
+		1A2B3C4D5E6F7890ABCDEF09 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF0A /* Main.storyboard */; };
+		1A2B3C4D5E6F7890ABCDEF0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF0C /* Assets.xcassets */; };
+		1A2B3C4D5E6F7890ABCDEF0D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF0E /* LaunchScreen.storyboard */; };
+		1A2B3C4D5E6F7890ABCDEF0F /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF10 /* manifest.json */; };
+		1A2B3C4D5E6F7890ABCDEF11 /* background.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF12 /* background.js */; };
+		1A2B3C4D5E6F7890ABCDEF13 /* content-script.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF14 /* content-script.js */; };
+		1A2B3C4D5E6F7890ABCDEF15 /* popup.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF16 /* popup.html */; };
+		1A2B3C4D5E6F7890ABCDEF17 /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF18 /* popup.js */; };
+		1A2B3C4D5E6F7890ABCDEF19 /* settings.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF1A /* settings.html */; };
+		1A2B3C4D5E6F7890ABCDEF1B /* settings.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF1C /* settings.js */; };
+		1A2B3C4D5E6F7890ABCDEF1D /* history.html in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF1E /* history.html */; };
+		1A2B3C4D5E6F7890ABCDEF1F /* history.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF20 /* history.js */; };
+		1A2B3C4D5E6F7890ABCDEF21 /* config.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF22 /* config.js */; };
+		1A2B3C4D5E6F7890ABCDEF23 /* utils/content-extractor.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF24 /* utils/content-extractor.js */; };
+		1A2B3C4D5E6F7890ABCDEF25 /* utils/system.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF26 /* utils/system.js */; };
+		1A2B3C4D5E6F7890ABCDEF27 /* db/HistoryStore.js in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF28 /* db/HistoryStore.js */; };
+		1A2B3C4D5E6F7890ABCDEF29 /* ChronicleSync_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7890ABCDEF2A /* ChronicleSync_Tests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1A2B3C4D5E6F7890ABCDEF2B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1A2B3C4D5E6F7890ABCDEF2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A2B3C4D5E6F7890ABCDEF2D;
+			remoteInfo = ChronicleSync;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1A2B3C4D5E6F7890ABCDEF02 /* SafariWebExtensionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebExtensionHandler.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF04 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF06 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF08 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF0A /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF0C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF0E /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF10 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF12 /* background.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = background.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF14 /* content-script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "content-script.js"; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF16 /* popup.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = popup.html; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF18 /* popup.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = popup.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF1A /* settings.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = settings.html; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF1C /* settings.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = settings.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF1E /* history.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = history.html; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF20 /* history.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = history.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF22 /* config.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = config.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF24 /* utils/content-extractor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "content-extractor.js"; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF26 /* utils/system.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = system.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF28 /* db/HistoryStore.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = HistoryStore.js; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF2A /* ChronicleSync_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronicleSync_Tests.swift; sourceTree = "<group>"; };
+		1A2B3C4D5E6F7890ABCDEF2D /* ChronicleSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChronicleSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A2B3C4D5E6F7890ABCDEF2E /* ChronicleSync Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ChronicleSync Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A2B3C4D5E6F7890ABCDEF2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A2B3C4D5E6F7890ABCDEF30 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A2B3C4D5E6F7890ABCDEF31 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A2B3C4D5E6F7890ABCDEF32 = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF33 /* ChronicleSync */,
+				1A2B3C4D5E6F7890ABCDEF34 /* ChronicleSync Tests */,
+				1A2B3C4D5E6F7890ABCDEF35 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF33 /* ChronicleSync */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF04 /* AppDelegate.swift */,
+				1A2B3C4D5E6F7890ABCDEF06 /* SceneDelegate.swift */,
+				1A2B3C4D5E6F7890ABCDEF08 /* ViewController.swift */,
+				1A2B3C4D5E6F7890ABCDEF0A /* Main.storyboard */,
+				1A2B3C4D5E6F7890ABCDEF0C /* Assets.xcassets */,
+				1A2B3C4D5E6F7890ABCDEF0E /* LaunchScreen.storyboard */,
+				1A2B3C4D5E6F7890ABCDEF2F /* Info.plist */,
+				1A2B3C4D5E6F7890ABCDEF02 /* SafariWebExtensionHandler.swift */,
+				1A2B3C4D5E6F7890ABCDEF36 /* Resources */,
+			);
+			path = ChronicleSync;
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF34 /* ChronicleSync Tests */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF2A /* ChronicleSync_Tests.swift */,
+			);
+			path = "ChronicleSync Tests";
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF35 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF2D /* ChronicleSync.app */,
+				1A2B3C4D5E6F7890ABCDEF2E /* ChronicleSync Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF36 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF10 /* manifest.json */,
+				1A2B3C4D5E6F7890ABCDEF12 /* background.js */,
+				1A2B3C4D5E6F7890ABCDEF14 /* content-script.js */,
+				1A2B3C4D5E6F7890ABCDEF16 /* popup.html */,
+				1A2B3C4D5E6F7890ABCDEF18 /* popup.js */,
+				1A2B3C4D5E6F7890ABCDEF1A /* settings.html */,
+				1A2B3C4D5E6F7890ABCDEF1C /* settings.js */,
+				1A2B3C4D5E6F7890ABCDEF1E /* history.html */,
+				1A2B3C4D5E6F7890ABCDEF20 /* history.js */,
+				1A2B3C4D5E6F7890ABCDEF22 /* config.js */,
+				1A2B3C4D5E6F7890ABCDEF37 /* utils */,
+				1A2B3C4D5E6F7890ABCDEF38 /* db */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF37 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF24 /* utils/content-extractor.js */,
+				1A2B3C4D5E6F7890ABCDEF26 /* utils/system.js */,
+			);
+			name = utils;
+			sourceTree = "<group>";
+		};
+		1A2B3C4D5E6F7890ABCDEF38 /* db */ = {
+			isa = PBXGroup;
+			children = (
+				1A2B3C4D5E6F7890ABCDEF28 /* db/HistoryStore.js */,
+			);
+			name = db;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A2B3C4D5E6F7890ABCDEF39 /* ChronicleSync */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A2B3C4D5E6F7890ABCDEF3A /* Build configuration list for PBXNativeTarget "ChronicleSync" */;
+			buildPhases = (
+				1A2B3C4D5E6F7890ABCDEF3B /* Sources */,
+				1A2B3C4D5E6F7890ABCDEF30 /* Frameworks */,
+				1A2B3C4D5E6F7890ABCDEF3C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChronicleSync;
+			productName = ChronicleSync;
+			productReference = 1A2B3C4D5E6F7890ABCDEF2D /* ChronicleSync.app */;
+			productType = "com.apple.product-type.application";
+		};
+		1A2B3C4D5E6F7890ABCDEF3D /* ChronicleSync Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A2B3C4D5E6F7890ABCDEF3E /* Build configuration list for PBXNativeTarget "ChronicleSync Tests" */;
+			buildPhases = (
+				1A2B3C4D5E6F7890ABCDEF3F /* Sources */,
+				1A2B3C4D5E6F7890ABCDEF31 /* Frameworks */,
+				1A2B3C4D5E6F7890ABCDEF40 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1A2B3C4D5E6F7890ABCDEF41 /* PBXTargetDependency */,
+			);
+			name = "ChronicleSync Tests";
+			productName = "ChronicleSync Tests";
+			productReference = 1A2B3C4D5E6F7890ABCDEF2E /* ChronicleSync Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A2B3C4D5E6F7890ABCDEF2C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					1A2B3C4D5E6F7890ABCDEF39 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					1A2B3C4D5E6F7890ABCDEF3D = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 1A2B3C4D5E6F7890ABCDEF39;
+					};
+				};
+			};
+			buildConfigurationList = 1A2B3C4D5E6F7890ABCDEF42 /* Build configuration list for PBXProject "ChronicleSync" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A2B3C4D5E6F7890ABCDEF32;
+			productRefGroup = 1A2B3C4D5E6F7890ABCDEF35 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A2B3C4D5E6F7890ABCDEF39 /* ChronicleSync */,
+				1A2B3C4D5E6F7890ABCDEF3D /* ChronicleSync Tests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A2B3C4D5E6F7890ABCDEF3C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A2B3C4D5E6F7890ABCDEF0D /* LaunchScreen.storyboard in Resources */,
+				1A2B3C4D5E6F7890ABCDEF0B /* Assets.xcassets in Resources */,
+				1A2B3C4D5E6F7890ABCDEF09 /* Main.storyboard in Resources */,
+				1A2B3C4D5E6F7890ABCDEF0F /* manifest.json in Resources */,
+				1A2B3C4D5E6F7890ABCDEF11 /* background.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF13 /* content-script.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF15 /* popup.html in Resources */,
+				1A2B3C4D5E6F7890ABCDEF17 /* popup.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF19 /* settings.html in Resources */,
+				1A2B3C4D5E6F7890ABCDEF1B /* settings.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF1D /* history.html in Resources */,
+				1A2B3C4D5E6F7890ABCDEF1F /* history.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF21 /* config.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF23 /* utils/content-extractor.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF25 /* utils/system.js in Resources */,
+				1A2B3C4D5E6F7890ABCDEF27 /* db/HistoryStore.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A2B3C4D5E6F7890ABCDEF40 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A2B3C4D5E6F7890ABCDEF3B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A2B3C4D5E6F7890ABCDEF07 /* ViewController.swift in Sources */,
+				1A2B3C4D5E6F7890ABCDEF03 /* AppDelegate.swift in Sources */,
+				1A2B3C4D5E6F7890ABCDEF05 /* SceneDelegate.swift in Sources */,
+				1A2B3C4D5E6F7890ABCDEF01 /* SafariWebExtensionHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1A2B3C4D5E6F7890ABCDEF3F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A2B3C4D5E6F7890ABCDEF29 /* ChronicleSync_Tests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A2B3C4D5E6F7890ABCDEF41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1A2B3C4D5E6F7890ABCDEF39 /* ChronicleSync */;
+			targetProxy = 1A2B3C4D5E6F7890ABCDEF2B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1A2B3C4D5E6F7890ABCDEF43 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1A2B3C4D5E6F7890ABCDEF44 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1A2B3C4D5E6F7890ABCDEF45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.chroniclesync.ChronicleSync;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A2B3C4D5E6F7890ABCDEF46 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChronicleSync/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = xyz.chroniclesync.ChronicleSync;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		1A2B3C4D5E6F7890ABCDEF47 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChronicleSync.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChronicleSync";
+			};
+			name = Debug;
+		};
+		1A2B3C4D5E6F7890ABCDEF48 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "xyz.chroniclesync.ChronicleSync-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChronicleSync.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ChronicleSync";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A2B3C4D5E6F7890ABCDEF3A /* Build configuration list for PBXNativeTarget "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A2B3C4D5E6F7890ABCDEF45 /* Debug */,
+				1A2B3C4D5E6F7890ABCDEF46 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A2B3C4D5E6F7890ABCDEF3E /* Build configuration list for PBXNativeTarget "ChronicleSync Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A2B3C4D5E6F7890ABCDEF47 /* Debug */,
+				1A2B3C4D5E6F7890ABCDEF48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A2B3C4D5E6F7890ABCDEF42 /* Build configuration list for PBXProject "ChronicleSync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A2B3C4D5E6F7890ABCDEF43 /* Debug */,
+				1A2B3C4D5E6F7890ABCDEF44 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A2B3C4D5E6F7890ABCDEF2C /* Project object */;
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/AppDelegate.swift
+++ b/extension/safari/ChronicleSync/ChronicleSync/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Info.plist
+++ b/extension/safari/ChronicleSync/ChronicleSync/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/extension/safari/ChronicleSync/ChronicleSync/LaunchScreen.storyboard
+++ b/extension/safari/ChronicleSync/ChronicleSync/LaunchScreen.storyboard
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ChronicleSync" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygc-Yd-Ixf">
+                                <rect key="frame" x="107.66666666666669" y="408.66666666666669" width="178" height="35"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ygc-Yd-Ixf" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Aqf-Yd-Ixf"/>
+                            <constraint firstItem="Ygc-Yd-Ixf" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="Ygc-Yd-Ixf"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/extension/safari/ChronicleSync/ChronicleSync/Main.storyboard
+++ b/extension/safari/ChronicleSync/ChronicleSync/Main.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ChronicleSync" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="132" y="-27"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/background.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/background.js
@@ -1,0 +1,377 @@
+// Safari-compatible background script
+import { getConfig } from './config.js';
+import { HistoryStore } from './db/HistoryStore.js';
+import { getSystemInfo } from './utils/system.js';
+
+const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+async function initializeExtension() {
+  try {
+    await browserAPI.storage.local.get(['initialized']);
+    await getConfig();
+    await browserAPI.storage.local.set({ initialized: true });
+    return true;
+  } catch (error) {
+    console.error('Failed to initialize extension:', error);
+    return false;
+  }
+}
+
+async function syncHistory(forceFullSync = false) {
+  try {
+    const initialized = await browserAPI.storage.local.get(['initialized']);
+    if (!initialized.initialized) {
+      const success = await initializeExtension();
+      if (!success) {
+        console.debug('Sync skipped: Extension not initialized');
+        return;
+      }
+    }
+
+    const config = await getConfig();
+
+    if (!config.clientId || config.clientId === 'extension-default') {
+      console.debug('Sync paused: No client ID configured');
+      throw new Error('Please configure your Client ID in the extension popup');
+    }
+
+    console.debug('Starting sync with client ID:', config.clientId);
+
+    const systemInfo = await getSystemInfo();
+    const now = Date.now();
+
+    const stored = await browserAPI.storage.local.get(['lastSync']);
+    const storedLastSync = stored.lastSync || 0;
+
+    const startTime = forceFullSync ? 0 : storedLastSync;
+
+    const historyStore = new HistoryStore();
+    await historyStore.init();
+
+    await historyStore.updateDevice(systemInfo);
+
+    // Safari history API is different, so we need to handle it differently
+    let historyItems = [];
+    
+    if (isSafari) {
+      // Safari-specific history implementation
+      try {
+        historyItems = await browserAPI.history.search({
+          text: '',
+          startTime: startTime,
+          endTime: now,
+          maxResults: 10000
+        });
+      } catch (error) {
+        console.error('Safari history API error:', error);
+        // If history API fails, we'll continue with an empty array
+      }
+    } else {
+      // Chrome history implementation
+      historyItems = await browserAPI.history.search({
+        text: '',
+        startTime: startTime,
+        endTime: now,
+        maxResults: 10000
+      });
+    }
+
+    const historyData = await Promise.all(historyItems.map(async item => {
+      if (!item.url) return [];
+      
+      let visits = [];
+      try {
+        visits = await browserAPI.history.getVisits({ url: item.url });
+      } catch (error) {
+        console.error('Error getting visits for URL:', item.url, error);
+        // If we can't get visits, create a single visit entry with current data
+        return [{
+          url: item.url,
+          title: item.title || '',
+          visitTime: item.lastVisitTime || Date.now(),
+          visitId: Date.now().toString(),
+          referringVisitId: '0',
+          transition: 'link',
+          ...systemInfo
+        }];
+      }
+      
+      return visits
+        .filter((visit) => {
+          const visitTime = visit.visitTime || 0;
+          return visitTime >= startTime && visitTime <= now;
+        })
+        .map((visit) => ({
+          url: item.url,
+          title: item.title || '',
+          visitTime: visit.visitTime || Date.now(),
+          visitId: visit.visitId?.toString() || Date.now().toString(),
+          referringVisitId: visit.referringVisitId?.toString() || '0',
+          transition: visit.transition || 'link',
+          ...systemInfo
+        }));
+    }));
+
+    const flattenedHistoryData = historyData.flat();
+    
+    for (const entry of flattenedHistoryData) {
+      await historyStore.addEntry(entry);
+    }
+
+    const unsyncedEntries = await historyStore.getUnsyncedEntries();
+
+    if (unsyncedEntries.length > 0) {
+      const response = await fetch(`${config.apiEndpoint}?clientId=${encodeURIComponent(config.clientId)}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          history: unsyncedEntries,
+          deviceInfo: systemInfo,
+          lastSync: storedLastSync
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const syncResponse = await response.json();
+
+      if (syncResponse.history && syncResponse.history.length > 0) {
+        await historyStore.mergeRemoteEntries(syncResponse.history);
+      }
+
+      if (syncResponse.devices) {
+        for (const device of syncResponse.devices) {
+          await historyStore.updateDevice(device);
+        }
+      }
+
+      for (const entry of unsyncedEntries) {
+        await historyStore.markAsSynced(entry.visitId);
+      }
+
+      const newLastSync = syncResponse.lastSyncTime || now;
+      const lastSyncDate = new Date(newLastSync).toLocaleString();
+      await browserAPI.storage.local.set({ lastSync: newLastSync });
+      
+      try {
+        await browserAPI.storage.sync.set({ lastSync: lastSyncDate });
+      } catch (error) {
+        console.warn('Could not save to sync storage:', error);
+        // Continue even if sync storage fails
+      }
+
+      try {
+        browserAPI.runtime.sendMessage({ 
+          type: 'syncComplete',
+          stats: {
+            sent: unsyncedEntries.length,
+            received: syncResponse.history?.length || 0,
+            devices: syncResponse.devices?.length || 0
+          }
+        }).catch(() => {
+          // Ignore error when no receivers are present
+        });
+      } catch {
+        // Catch any other messaging errors
+      }
+    }
+
+    console.debug('Successfully completed sync');
+  } catch (error) {
+    console.error('Error syncing history:', error);
+    try {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      browserAPI.runtime.sendMessage({ 
+        type: 'syncError',
+        error: errorMessage
+      }).catch(() => {
+        // Ignore error when no receivers are present
+      });
+    } catch {
+      // Catch any other messaging errors
+    }
+  }
+}
+
+// Initial sync with full history
+syncHistory(true);
+
+// Set up periodic sync
+setInterval(() => syncHistory(false), SYNC_INTERVAL);
+
+// Listen for navigation events
+browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, _tab) => {
+  if (changeInfo.url) {
+    console.debug(`Navigation to: ${changeInfo.url}`);
+    setTimeout(() => syncHistory(false), 1000);
+  }
+});
+
+// Listen for messages from the page
+browserAPI.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'getClientId') {
+    browserAPI.storage.local.get(['initialized']).then(async result => {
+      if (!result.initialized) {
+        const success = await initializeExtension();
+        if (!success) {
+          sendResponse({ error: 'Extension not initialized' });
+          return;
+        }
+      }
+
+      try {
+        const config = await getConfig();
+        sendResponse({ clientId: config.clientId === 'extension-default' ? null : config.clientId });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error getting client ID:', errorMessage);
+        sendResponse({ error: 'Failed to get client ID' });
+      }
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'triggerSync') {
+    syncHistory(true)
+      .then(() => {
+        sendResponse({ success: true, message: 'Sync successful' });
+      })
+      .catch(error => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Manual sync failed:', errorMessage);
+        sendResponse({ error: errorMessage });
+      });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'getHistory') {
+    const { deviceId, since, limit } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const entries = await historyStore.getEntries(deviceId, since);
+        const limitedEntries = limit ? entries.slice(0, limit) : entries;
+        sendResponse(limitedEntries);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error fetching history from IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'getDevices') {
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const devices = await historyStore.getDevices();
+        sendResponse(devices);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error fetching devices from IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'deleteHistory') {
+    const { visitId } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        await historyStore.deleteEntry(visitId);
+        await syncHistory(false);
+        sendResponse({ success: true });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error deleting history entry:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'pageContentExtracted') {
+    // Handle page content extraction from content script
+    const { url, content, summary } = request.data;
+    if (url && (content || summary)) {
+      const historyStore = new HistoryStore();
+      historyStore.init().then(async () => {
+        try {
+          await historyStore.updatePageContent(url, { content, summary });
+          console.debug('Updated page content for:', url);
+          sendResponse({ success: true });
+          
+          // Trigger a sync to send the updated content to the server
+          setTimeout(() => syncHistory(false), 1000);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          console.error('Error updating page content:', errorMessage);
+          sendResponse({ error: errorMessage });
+        }
+      }).catch(error => {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error initializing IndexedDB:', errorMessage);
+        sendResponse({ error: errorMessage });
+      });
+      return true; // Will respond asynchronously
+    }
+  } else if (request.type === 'searchHistory') {
+    const { query } = request;
+    const historyStore = new HistoryStore();
+    historyStore.init().then(async () => {
+      try {
+        const results = await historyStore.searchContent(query);
+        
+        // Format the results for display
+        const formattedResults = results.map(result => ({
+          visitId: result.entry.visitId,
+          url: result.entry.url,
+          title: result.entry.title,
+          visitTime: result.entry.visitTime,
+          matches: result.matches
+        }));
+        
+        sendResponse({ success: true, results: formattedResults });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error searching history:', errorMessage);
+        sendResponse({ error: errorMessage });
+      }
+    }).catch(error => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error initializing IndexedDB:', errorMessage);
+      sendResponse({ error: errorMessage });
+    });
+    return true; // Will respond asynchronously
+  } else if (request.type === 'checkSettings') {
+    // Safari-specific: Check if settings are configured
+    browserAPI.storage.local.get(['initialized']).then(async result => {
+      if (!result.initialized) {
+        sendResponse({ configured: false });
+        return;
+      }
+      
+      try {
+        const config = await getConfig();
+        const isConfigured = config.clientId && config.clientId !== 'extension-default';
+        sendResponse({ configured: isConfigured });
+      } catch (error) {
+        sendResponse({ configured: false, error: String(error) });
+      }
+    });
+    return true; // Will respond asynchronously
+  }
+});

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/config.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/config.js
@@ -1,0 +1,67 @@
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+// Default configuration
+const DEFAULT_CONFIG = {
+  clientId: 'extension-default',
+  environment: 'production',
+  customApiUrl: '',
+  expirationDays: 7,
+  apiEndpoint: 'https://api.chroniclesync.xyz/sync'
+};
+
+// Get the current configuration
+export async function getConfig() {
+  try {
+    const result = await browserAPI.storage.local.get(['config']);
+    const config = result.config || {};
+    
+    // Merge with defaults for any missing properties
+    return {
+      ...DEFAULT_CONFIG,
+      ...config,
+      // Compute the API endpoint based on environment
+      apiEndpoint: getApiEndpoint(config.environment || DEFAULT_CONFIG.environment, config.customApiUrl)
+    };
+  } catch (error) {
+    console.error('Error loading config:', error);
+    return DEFAULT_CONFIG;
+  }
+}
+
+// Save configuration
+export async function saveConfig(config) {
+  try {
+    await browserAPI.storage.local.set({ config });
+    return true;
+  } catch (error) {
+    console.error('Error saving config:', error);
+    return false;
+  }
+}
+
+// Reset configuration to defaults
+export async function resetConfig() {
+  try {
+    await browserAPI.storage.local.set({ config: DEFAULT_CONFIG });
+    return true;
+  } catch (error) {
+    console.error('Error resetting config:', error);
+    return false;
+  }
+}
+
+// Get API endpoint based on environment
+function getApiEndpoint(environment, customUrl) {
+  switch (environment) {
+    case 'production':
+      return 'https://api.chroniclesync.xyz/sync';
+    case 'staging':
+      return 'https://api-staging.chroniclesync.xyz/sync';
+    case 'custom':
+      return customUrl || DEFAULT_CONFIG.apiEndpoint;
+    default:
+      return DEFAULT_CONFIG.apiEndpoint;
+  }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/content-script.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/content-script.js
@@ -1,0 +1,78 @@
+// Content script to extract and summarize webpage content
+import { extractPageContent } from './utils/content-extractor.js';
+
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+// Extract content when the page loads
+function processPageContent() {
+  try {
+    const pageContent = extractPageContent();
+    
+    // Send the extracted content to the background script
+    browserAPI.runtime.sendMessage({
+      type: 'pageContentExtracted',
+      data: {
+        url: window.location.href,
+        title: document.title,
+        content: pageContent.content,
+        summary: pageContent.summary,
+        timestamp: Date.now()
+      }
+    });
+  } catch (error) {
+    console.error('Error extracting page content:', error);
+  }
+}
+
+// Process content after the page has fully loaded
+window.addEventListener('load', () => {
+  // Wait a bit for dynamic content to load
+  setTimeout(processPageContent, 1000);
+});
+
+// Listen for messages from the background script
+browserAPI.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'searchPageContent') {
+    const { query } = request;
+    try {
+      const pageContent = extractPageContent();
+      const searchResults = searchContent(pageContent.content, query);
+      sendResponse({ success: true, results: searchResults });
+    } catch (error) {
+      sendResponse({ success: false, error: String(error) });
+    }
+    return true; // Will respond asynchronously
+  }
+});
+
+// Function to search content and return matches with context
+function searchContent(content, query) {
+  if (!query || !content) return [];
+  
+  const results = [];
+  const lowerContent = content.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  
+  let startIndex = 0;
+  while (startIndex < lowerContent.length) {
+    const foundIndex = lowerContent.indexOf(lowerQuery, startIndex);
+    if (foundIndex === -1) break;
+    
+    // Get context around the match (100 chars before and after)
+    const contextStart = Math.max(0, foundIndex - 100);
+    const contextEnd = Math.min(content.length, foundIndex + query.length + 100);
+    const matchText = content.substring(foundIndex, foundIndex + query.length);
+    const context = content.substring(contextStart, contextEnd);
+    
+    results.push({
+      text: matchText,
+      context: context
+    });
+    
+    startIndex = foundIndex + query.length;
+  }
+  
+  return results;
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/db/HistoryStore.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/db/HistoryStore.js
@@ -1,0 +1,415 @@
+// IndexedDB storage for history entries
+
+// Database configuration
+const DB_NAME = 'chroniclesync';
+const DB_VERSION = 1;
+const HISTORY_STORE = 'history';
+const DEVICES_STORE = 'devices';
+
+export class HistoryStore {
+  constructor() {
+    this.db = null;
+  }
+  
+  // Initialize the database
+  async init() {
+    if (this.db) {
+      return;
+    }
+    
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      
+      request.onerror = (event) => {
+        console.error('Error opening database:', event.target.error);
+        reject(event.target.error);
+      };
+      
+      request.onsuccess = (event) => {
+        this.db = event.target.result;
+        resolve();
+      };
+      
+      request.onupgradeneeded = (event) => {
+        const db = event.target.result;
+        
+        // Create history store
+        if (!db.objectStoreNames.contains(HISTORY_STORE)) {
+          const historyStore = db.createObjectStore(HISTORY_STORE, { keyPath: 'visitId' });
+          historyStore.createIndex('url', 'url', { unique: false });
+          historyStore.createIndex('visitTime', 'visitTime', { unique: false });
+          historyStore.createIndex('deviceId', 'deviceId', { unique: false });
+          historyStore.createIndex('synced', 'synced', { unique: false });
+        }
+        
+        // Create devices store
+        if (!db.objectStoreNames.contains(DEVICES_STORE)) {
+          const devicesStore = db.createObjectStore(DEVICES_STORE, { keyPath: 'deviceId' });
+          devicesStore.createIndex('name', 'name', { unique: false });
+          devicesStore.createIndex('type', 'type', { unique: false });
+        }
+      };
+    });
+  }
+  
+  // Add a history entry
+  async addEntry(entry) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(HISTORY_STORE);
+      
+      // Add synced flag (false by default)
+      const entryWithSync = {
+        ...entry,
+        synced: false
+      };
+      
+      const request = store.put(entryWithSync);
+      
+      request.onsuccess = () => {
+        resolve();
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error adding history entry:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Get history entries
+  async getEntries(deviceId = null, since = 0, limit = 1000) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(HISTORY_STORE);
+      
+      let request;
+      
+      if (deviceId) {
+        // Get entries for a specific device
+        const index = store.index('deviceId');
+        request = index.openCursor(IDBKeyRange.only(deviceId));
+      } else {
+        // Get all entries
+        request = store.openCursor();
+      }
+      
+      const entries = [];
+      
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        
+        if (cursor) {
+          const entry = cursor.value;
+          
+          // Filter by time if needed
+          if (entry.visitTime >= since) {
+            entries.push(entry);
+          }
+          
+          // Stop if we've reached the limit
+          if (entries.length >= limit) {
+            resolve(entries);
+          } else {
+            cursor.continue();
+          }
+        } else {
+          // Sort by visit time (newest first)
+          entries.sort((a, b) => b.visitTime - a.visitTime);
+          resolve(entries);
+        }
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error getting history entries:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Get unsynced entries
+  async getUnsyncedEntries() {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(HISTORY_STORE);
+      const index = store.index('synced');
+      const request = index.openCursor(IDBKeyRange.only(false));
+      
+      const entries = [];
+      
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        
+        if (cursor) {
+          entries.push(cursor.value);
+          cursor.continue();
+        } else {
+          resolve(entries);
+        }
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error getting unsynced entries:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Mark an entry as synced
+  async markAsSynced(visitId) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(HISTORY_STORE);
+      const request = store.get(visitId);
+      
+      request.onsuccess = (event) => {
+        const entry = event.target.result;
+        
+        if (entry) {
+          entry.synced = true;
+          const updateRequest = store.put(entry);
+          
+          updateRequest.onsuccess = () => {
+            resolve();
+          };
+          
+          updateRequest.onerror = (event) => {
+            console.error('Error marking entry as synced:', event.target.error);
+            reject(event.target.error);
+          };
+        } else {
+          resolve(); // Entry not found, nothing to do
+        }
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error getting entry to mark as synced:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Merge remote entries
+  async mergeRemoteEntries(entries) {
+    await this.init();
+    
+    for (const entry of entries) {
+      await this.addEntry({
+        ...entry,
+        synced: true // Mark as already synced
+      });
+    }
+  }
+  
+  // Update device information
+  async updateDevice(device) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([DEVICES_STORE], 'readwrite');
+      const store = transaction.objectStore(DEVICES_STORE);
+      
+      const request = store.put(device);
+      
+      request.onsuccess = () => {
+        resolve();
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error updating device:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Get all devices
+  async getDevices() {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([DEVICES_STORE], 'readonly');
+      const store = transaction.objectStore(DEVICES_STORE);
+      const request = store.getAll();
+      
+      request.onsuccess = (event) => {
+        resolve(event.target.result);
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error getting devices:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Delete a history entry
+  async deleteEntry(visitId) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(HISTORY_STORE);
+      const request = store.delete(visitId);
+      
+      request.onsuccess = () => {
+        resolve();
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error deleting history entry:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Update page content for a URL
+  async updatePageContent(url, { content, summary }) {
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readwrite');
+      const store = transaction.objectStore(HISTORY_STORE);
+      const index = store.index('url');
+      const request = index.openCursor(IDBKeyRange.only(url));
+      
+      let updated = false;
+      
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        
+        if (cursor) {
+          const entry = cursor.value;
+          
+          // Update content and summary
+          entry.content = content || entry.content;
+          entry.summary = summary || entry.summary;
+          entry.synced = false; // Mark as needing sync
+          
+          const updateRequest = store.put(entry);
+          
+          updateRequest.onsuccess = () => {
+            updated = true;
+            cursor.continue();
+          };
+          
+          updateRequest.onerror = (event) => {
+            console.error('Error updating page content:', event.target.error);
+            reject(event.target.error);
+          };
+        } else {
+          resolve(updated);
+        }
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error finding entries for URL:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+  
+  // Search content in history entries
+  async searchContent(query) {
+    if (!query) {
+      return [];
+    }
+    
+    await this.init();
+    
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([HISTORY_STORE], 'readonly');
+      const store = transaction.objectStore(HISTORY_STORE);
+      const request = store.openCursor();
+      
+      const results = [];
+      const lowerQuery = query.toLowerCase();
+      
+      request.onsuccess = (event) => {
+        const cursor = event.target.result;
+        
+        if (cursor) {
+          const entry = cursor.value;
+          let matches = [];
+          
+          // Search in title
+          if (entry.title && entry.title.toLowerCase().includes(lowerQuery)) {
+            matches.push({
+              field: 'title',
+              text: entry.title,
+              context: entry.title
+            });
+          }
+          
+          // Search in URL
+          if (entry.url && entry.url.toLowerCase().includes(lowerQuery)) {
+            matches.push({
+              field: 'url',
+              text: entry.url,
+              context: entry.url
+            });
+          }
+          
+          // Search in content
+          if (entry.content) {
+            const lowerContent = entry.content.toLowerCase();
+            let startIndex = 0;
+            
+            while (startIndex < lowerContent.length) {
+              const foundIndex = lowerContent.indexOf(lowerQuery, startIndex);
+              
+              if (foundIndex === -1) {
+                break;
+              }
+              
+              // Get context around the match
+              const contextStart = Math.max(0, foundIndex - 50);
+              const contextEnd = Math.min(entry.content.length, foundIndex + query.length + 50);
+              const matchText = entry.content.substring(foundIndex, foundIndex + query.length);
+              const context = entry.content.substring(contextStart, contextEnd);
+              
+              matches.push({
+                field: 'content',
+                text: matchText,
+                context: context
+              });
+              
+              startIndex = foundIndex + query.length;
+              
+              // Limit to 5 matches per entry
+              if (matches.length >= 5) {
+                break;
+              }
+            }
+          }
+          
+          // Add to results if there are matches
+          if (matches.length > 0) {
+            results.push({
+              entry,
+              matches
+            });
+          }
+          
+          cursor.continue();
+        } else {
+          // Sort by visit time (newest first)
+          results.sort((a, b) => b.entry.visitTime - a.entry.visitTime);
+          resolve(results);
+        }
+      };
+      
+      request.onerror = (event) => {
+        console.error('Error searching content:', event.target.error);
+        reject(event.target.error);
+      };
+    });
+  }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/history.html
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/history.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chronicle Sync History</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: #F2F2F7;
+        color: #333;
+      }
+      
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+        background-color: white;
+        padding: 15px 20px;
+        border-radius: 10px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      }
+      
+      h1 {
+        font-size: 24px;
+        margin: 0;
+        color: #000;
+      }
+      
+      .search-container {
+        display: flex;
+        gap: 10px;
+        width: 50%;
+      }
+      
+      .search-input {
+        flex-grow: 1;
+        padding: 10px;
+        border: 1px solid #D1D1D6;
+        border-radius: 6px;
+        font-size: 14px;
+      }
+      
+      .search-input:focus {
+        outline: none;
+        border-color: #0077FF;
+      }
+      
+      .search-button {
+        background-color: #0077FF;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        padding: 10px 16px;
+        font-size: 14px;
+        cursor: pointer;
+      }
+      
+      .search-button:hover {
+        background-color: #0055CC;
+      }
+      
+      .filters {
+        display: flex;
+        gap: 15px;
+        margin-bottom: 20px;
+        background-color: white;
+        padding: 15px 20px;
+        border-radius: 10px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      }
+      
+      .filter-group {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      
+      .filter-label {
+        font-size: 14px;
+        font-weight: 500;
+      }
+      
+      .filter-select {
+        padding: 8px;
+        border: 1px solid #D1D1D6;
+        border-radius: 6px;
+        font-size: 14px;
+      }
+      
+      .history-list {
+        background-color: white;
+        border-radius: 10px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        overflow: hidden;
+      }
+      
+      .history-item {
+        padding: 15px 20px;
+        border-bottom: 1px solid #E5E5EA;
+        transition: background-color 0.2s;
+      }
+      
+      .history-item:last-child {
+        border-bottom: none;
+      }
+      
+      .history-item:hover {
+        background-color: #F2F2F7;
+      }
+      
+      .history-title {
+        font-size: 16px;
+        font-weight: 500;
+        margin: 0 0 5px 0;
+        color: #0077FF;
+      }
+      
+      .history-url {
+        font-size: 14px;
+        color: #8E8E93;
+        margin: 0 0 5px 0;
+        word-break: break-all;
+      }
+      
+      .history-meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        color: #8E8E93;
+      }
+      
+      .history-time {
+        font-style: italic;
+      }
+      
+      .history-device {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+      }
+      
+      .device-icon {
+        width: 16px;
+        height: 16px;
+      }
+      
+      .no-results {
+        padding: 30px;
+        text-align: center;
+        color: #8E8E93;
+      }
+      
+      .loading {
+        padding: 30px;
+        text-align: center;
+        color: #8E8E93;
+      }
+      
+      .pagination {
+        display: flex;
+        justify-content: center;
+        gap: 10px;
+        margin-top: 20px;
+      }
+      
+      .pagination-button {
+        background-color: white;
+        border: 1px solid #D1D1D6;
+        border-radius: 6px;
+        padding: 8px 12px;
+        font-size: 14px;
+        cursor: pointer;
+      }
+      
+      .pagination-button:hover {
+        background-color: #F2F2F7;
+      }
+      
+      .pagination-button.active {
+        background-color: #0077FF;
+        color: white;
+        border-color: #0077FF;
+      }
+      
+      .pagination-button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>ChronicleSync History</h1>
+        <div class="search-container">
+          <input type="text" id="searchInput" class="search-input" placeholder="Search your browsing history...">
+          <button id="searchButton" class="search-button">Search</button>
+        </div>
+      </header>
+      
+      <div class="filters">
+        <div class="filter-group">
+          <span class="filter-label">Device:</span>
+          <select id="deviceFilter" class="filter-select">
+            <option value="all">All Devices</option>
+            <!-- Devices will be populated dynamically -->
+          </select>
+        </div>
+        
+        <div class="filter-group">
+          <span class="filter-label">Time Range:</span>
+          <select id="timeFilter" class="filter-select">
+            <option value="all">All Time</option>
+            <option value="today">Today</option>
+            <option value="yesterday">Yesterday</option>
+            <option value="week">Last 7 Days</option>
+            <option value="month">Last 30 Days</option>
+          </select>
+        </div>
+      </div>
+      
+      <div id="historyContainer" class="history-list">
+        <div class="loading">Loading history...</div>
+      </div>
+      
+      <div id="pagination" class="pagination">
+        <!-- Pagination will be populated dynamically -->
+      </div>
+    </div>
+    
+    <script src="history.js" type="module"></script>
+  </body>
+</html>

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/history.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/history.js
@@ -1,0 +1,318 @@
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+// Constants
+const ITEMS_PER_PAGE = 20;
+
+// State
+let historyData = [];
+let devices = [];
+let currentPage = 1;
+let currentDeviceFilter = 'all';
+let currentTimeFilter = 'all';
+let currentSearchQuery = '';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  // Initialize UI elements
+  const historyContainer = document.getElementById('historyContainer');
+  const deviceFilter = document.getElementById('deviceFilter');
+  const timeFilter = document.getElementById('timeFilter');
+  const searchInput = document.getElementById('searchInput');
+  const searchButton = document.getElementById('searchButton');
+  const pagination = document.getElementById('pagination');
+  
+  // Load devices
+  try {
+    devices = await browserAPI.runtime.sendMessage({ type: 'getDevices' });
+    populateDeviceFilter(devices);
+  } catch (error) {
+    console.error('Error loading devices:', error);
+    showError('Failed to load devices. Please try again later.');
+  }
+  
+  // Load initial history data
+  await loadHistoryData();
+  
+  // Set up event listeners
+  deviceFilter.addEventListener('change', async () => {
+    currentDeviceFilter = deviceFilter.value;
+    currentPage = 1;
+    await loadHistoryData();
+  });
+  
+  timeFilter.addEventListener('change', async () => {
+    currentTimeFilter = timeFilter.value;
+    currentPage = 1;
+    await loadHistoryData();
+  });
+  
+  searchButton.addEventListener('click', async () => {
+    currentSearchQuery = searchInput.value.trim();
+    currentPage = 1;
+    await loadHistoryData();
+  });
+  
+  searchInput.addEventListener('keypress', async (e) => {
+    if (e.key === 'Enter') {
+      currentSearchQuery = searchInput.value.trim();
+      currentPage = 1;
+      await loadHistoryData();
+    }
+  });
+});
+
+// Load history data based on current filters
+async function loadHistoryData() {
+  const historyContainer = document.getElementById('historyContainer');
+  historyContainer.innerHTML = '<div class="loading">Loading history...</div>';
+  
+  try {
+    if (currentSearchQuery) {
+      // Search mode
+      const response = await browserAPI.runtime.sendMessage({ 
+        type: 'searchHistory',
+        query: currentSearchQuery
+      });
+      
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      
+      historyData = response.results || [];
+    } else {
+      // Normal history mode
+      const since = getTimeFilterTimestamp(currentTimeFilter);
+      const deviceId = currentDeviceFilter === 'all' ? null : currentDeviceFilter;
+      
+      historyData = await browserAPI.runtime.sendMessage({ 
+        type: 'getHistory',
+        deviceId: deviceId,
+        since: since
+      });
+      
+      if (historyData.error) {
+        throw new Error(historyData.error);
+      }
+    }
+    
+    // Sort by visit time (newest first)
+    historyData.sort((a, b) => b.visitTime - a.visitTime);
+    
+    renderHistoryItems();
+    renderPagination();
+  } catch (error) {
+    console.error('Error loading history:', error);
+    historyContainer.innerHTML = `
+      <div class="no-results">
+        <p>Error loading history: ${error.message || 'Unknown error'}</p>
+      </div>
+    `;
+  }
+}
+
+// Render history items for the current page
+function renderHistoryItems() {
+  const historyContainer = document.getElementById('historyContainer');
+  historyContainer.innerHTML = '';
+  
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
+  const pageItems = historyData.slice(startIndex, endIndex);
+  
+  if (pageItems.length === 0) {
+    historyContainer.innerHTML = `
+      <div class="no-results">
+        <p>No history items found${currentSearchQuery ? ' for your search' : ''}.</p>
+      </div>
+    `;
+    return;
+  }
+  
+  for (const item of pageItems) {
+    const historyItem = document.createElement('div');
+    historyItem.className = 'history-item';
+    
+    const visitDate = new Date(item.visitTime).toLocaleString();
+    const deviceInfo = getDeviceInfo(item.deviceId);
+    const deviceName = deviceInfo ? deviceInfo.name : 'Unknown Device';
+    const deviceIcon = getDeviceIcon(deviceInfo ? deviceInfo.type : 'unknown');
+    
+    historyItem.innerHTML = `
+      <h3 class="history-title">${escapeHtml(item.title || 'Untitled')}</h3>
+      <p class="history-url">${escapeHtml(item.url)}</p>
+      <div class="history-meta">
+        <span class="history-time">${visitDate}</span>
+        <span class="history-device">
+          ${deviceIcon}
+          ${escapeHtml(deviceName)}
+        </span>
+      </div>
+    `;
+    
+    historyItem.addEventListener('click', () => {
+      browserAPI.tabs.create({ url: item.url });
+    });
+    
+    historyContainer.appendChild(historyItem);
+  }
+}
+
+// Render pagination controls
+function renderPagination() {
+  const pagination = document.getElementById('pagination');
+  pagination.innerHTML = '';
+  
+  const totalPages = Math.ceil(historyData.length / ITEMS_PER_PAGE);
+  
+  if (totalPages <= 1) {
+    return;
+  }
+  
+  // Previous button
+  const prevButton = document.createElement('button');
+  prevButton.className = 'pagination-button';
+  prevButton.textContent = '← Previous';
+  prevButton.disabled = currentPage === 1;
+  prevButton.addEventListener('click', () => {
+    if (currentPage > 1) {
+      currentPage--;
+      renderHistoryItems();
+      renderPagination();
+      window.scrollTo(0, 0);
+    }
+  });
+  pagination.appendChild(prevButton);
+  
+  // Page numbers
+  const maxVisiblePages = 5;
+  let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
+  let endPage = Math.min(totalPages, startPage + maxVisiblePages - 1);
+  
+  if (endPage - startPage + 1 < maxVisiblePages) {
+    startPage = Math.max(1, endPage - maxVisiblePages + 1);
+  }
+  
+  for (let i = startPage; i <= endPage; i++) {
+    const pageButton = document.createElement('button');
+    pageButton.className = `pagination-button ${i === currentPage ? 'active' : ''}`;
+    pageButton.textContent = i.toString();
+    pageButton.addEventListener('click', () => {
+      currentPage = i;
+      renderHistoryItems();
+      renderPagination();
+      window.scrollTo(0, 0);
+    });
+    pagination.appendChild(pageButton);
+  }
+  
+  // Next button
+  const nextButton = document.createElement('button');
+  nextButton.className = 'pagination-button';
+  nextButton.textContent = 'Next →';
+  nextButton.disabled = currentPage === totalPages;
+  nextButton.addEventListener('click', () => {
+    if (currentPage < totalPages) {
+      currentPage++;
+      renderHistoryItems();
+      renderPagination();
+      window.scrollTo(0, 0);
+    }
+  });
+  pagination.appendChild(nextButton);
+}
+
+// Populate device filter dropdown
+function populateDeviceFilter(devices) {
+  const deviceFilter = document.getElementById('deviceFilter');
+  
+  // Keep the "All Devices" option
+  deviceFilter.innerHTML = '<option value="all">All Devices</option>';
+  
+  for (const device of devices) {
+    const option = document.createElement('option');
+    option.value = device.deviceId;
+    option.textContent = device.name || 'Unknown Device';
+    deviceFilter.appendChild(option);
+  }
+}
+
+// Get device info by ID
+function getDeviceInfo(deviceId) {
+  return devices.find(device => device.deviceId === deviceId);
+}
+
+// Get device icon based on device type
+function getDeviceIcon(deviceType) {
+  let icon = '';
+  
+  switch (deviceType.toLowerCase()) {
+    case 'desktop':
+    case 'laptop':
+      icon = '💻';
+      break;
+    case 'tablet':
+      icon = '📱';
+      break;
+    case 'mobile':
+      icon = '📱';
+      break;
+    default:
+      icon = '🔍';
+  }
+  
+  return icon;
+}
+
+// Get timestamp for time filter
+function getTimeFilterTimestamp(filter) {
+  const now = new Date();
+  
+  switch (filter) {
+    case 'today':
+      const today = new Date(now);
+      today.setHours(0, 0, 0, 0);
+      return today.getTime();
+      
+    case 'yesterday':
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(0, 0, 0, 0);
+      return yesterday.getTime();
+      
+    case 'week':
+      const week = new Date(now);
+      week.setDate(week.getDate() - 7);
+      return week.getTime();
+      
+    case 'month':
+      const month = new Date(now);
+      month.setDate(month.getDate() - 30);
+      return month.getTime();
+      
+    case 'all':
+    default:
+      return 0;
+  }
+}
+
+// Show error message
+function showError(message) {
+  const historyContainer = document.getElementById('historyContainer');
+  historyContainer.innerHTML = `
+    <div class="no-results">
+      <p>${message}</p>
+    </div>
+  `;
+}
+
+// Helper function to escape HTML
+function escapeHtml(unsafe) {
+  if (!unsafe) return '';
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/manifest.json
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/manifest.json
@@ -1,0 +1,33 @@
+{
+  "manifest_version": 3,
+  "name": "ChronicleSync Extension",
+  "version": "1.0",
+  "description": "ChronicleSync Safari Extension",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "tabs",
+    "history",
+    "storage",
+    "unlimitedStorage"
+  ],
+  "host_permissions": [
+    "http://localhost:*/*",
+    "https://api.chroniclesync.xyz/*",
+    "https://api-staging.chroniclesync.xyz/*"
+  ]
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/popup.html
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/popup.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ChronicleSync Extension</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      margin: 0;
+      padding: 16px;
+      width: 320px;
+      color: #333;
+    }
+    
+    h1 {
+      font-size: 18px;
+      margin-top: 0;
+      margin-bottom: 16px;
+      color: #000;
+    }
+    
+    .button-container {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 16px;
+    }
+    
+    button {
+      background-color: #0077FF;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 8px 16px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+    
+    button:hover {
+      background-color: #0055CC;
+    }
+    
+    .secondary-button {
+      background-color: #F2F2F7;
+      color: #0077FF;
+      border: 1px solid #0077FF;
+    }
+    
+    .secondary-button:hover {
+      background-color: #E5E5EA;
+    }
+    
+    .status {
+      margin-top: 16px;
+      padding: 10px;
+      border-radius: 6px;
+      font-size: 14px;
+    }
+    
+    .success {
+      background-color: #E8F5E9;
+      color: #2E7D32;
+    }
+    
+    .error {
+      background-color: #FFEBEE;
+      color: #C62828;
+    }
+    
+    .info {
+      background-color: #E3F2FD;
+      color: #1565C0;
+    }
+  </style>
+</head>
+<body>
+  <h1>ChronicleSync</h1>
+  
+  <div id="status-container"></div>
+  
+  <div class="button-container">
+    <button id="viewHistory">View History</button>
+    <button id="openSettings">Settings</button>
+    <button id="syncNow" class="secondary-button">Sync Now</button>
+  </div>
+  
+  <script src="popup.js" type="module"></script>
+</body>
+</html>

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/popup.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/popup.js
@@ -1,0 +1,83 @@
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const viewHistoryButton = document.getElementById('viewHistory');
+  const openSettingsButton = document.getElementById('openSettings');
+  const syncNowButton = document.getElementById('syncNow');
+  const statusContainer = document.getElementById('status-container');
+  
+  // Check if settings are configured
+  try {
+    const response = await browserAPI.runtime.sendMessage({ type: 'checkSettings' });
+    
+    if (!response.configured) {
+      showStatus('Please configure your settings first', 'info');
+      
+      // If not configured, automatically open settings when clicked
+      viewHistoryButton.addEventListener('click', () => {
+        browserAPI.runtime.sendMessage({ type: 'openSettings' });
+        window.close();
+      });
+    } else {
+      // Normal behavior when configured
+      viewHistoryButton.addEventListener('click', () => {
+        browserAPI.tabs.create({ url: 'history.html' });
+        window.close();
+      });
+    }
+  } catch (error) {
+    console.error('Error checking settings:', error);
+    showStatus('Error checking settings', 'error');
+  }
+  
+  // Settings button always opens settings
+  openSettingsButton.addEventListener('click', () => {
+    browserAPI.tabs.create({ url: 'settings.html' });
+    window.close();
+  });
+  
+  // Sync now button
+  syncNowButton.addEventListener('click', async () => {
+    try {
+      showStatus('Syncing...', 'info');
+      syncNowButton.disabled = true;
+      
+      const response = await browserAPI.runtime.sendMessage({ type: 'triggerSync' });
+      
+      if (response.error) {
+        showStatus(`Sync failed: ${response.error}`, 'error');
+      } else {
+        showStatus('Sync completed successfully!', 'success');
+      }
+    } catch (error) {
+      showStatus(`Sync error: ${error.message || 'Unknown error'}`, 'error');
+    } finally {
+      syncNowButton.disabled = false;
+    }
+  });
+  
+  // Check last sync time
+  try {
+    const data = await browserAPI.storage.local.get(['lastSync']);
+    if (data.lastSync) {
+      const lastSyncDate = new Date(data.lastSync).toLocaleString();
+      showStatus(`Last synced: ${lastSyncDate}`, 'info');
+    }
+  } catch (error) {
+    console.error('Error getting last sync time:', error);
+  }
+});
+
+// Helper function to show status messages
+function showStatus(message, type) {
+  const statusContainer = document.getElementById('status-container');
+  statusContainer.innerHTML = '';
+  
+  const statusElement = document.createElement('div');
+  statusElement.className = `status ${type}`;
+  statusElement.textContent = message;
+  
+  statusContainer.appendChild(statusElement);
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/settings.html
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/settings.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ChronicleSync Settings</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+            margin: 0;
+            padding: 20px;
+            color: #333;
+            background-color: #F2F2F7;
+        }
+        
+        .settings-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background-color: white;
+            border-radius: 10px;
+            padding: 20px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        
+        h1 {
+            font-size: 24px;
+            margin-top: 0;
+            color: #000;
+            border-bottom: 1px solid #E5E5EA;
+            padding-bottom: 10px;
+        }
+        
+        h2 {
+            font-size: 18px;
+            margin-top: 20px;
+            color: #000;
+        }
+        
+        .settings-section {
+            margin-bottom: 30px;
+        }
+        
+        .setting-item {
+            margin-bottom: 15px;
+        }
+        
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 500;
+        }
+        
+        input, textarea, select {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #D1D1D6;
+            border-radius: 6px;
+            font-size: 14px;
+            box-sizing: border-box;
+        }
+        
+        input:focus, textarea:focus, select:focus {
+            outline: none;
+            border-color: #0077FF;
+        }
+        
+        .help-text {
+            display: block;
+            font-size: 12px;
+            color: #8E8E93;
+            margin-top: 5px;
+        }
+        
+        .mnemonic-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+        }
+        
+        .settings-actions {
+            display: flex;
+            justify-content: space-between;
+            margin-top: 30px;
+        }
+        
+        button {
+            padding: 10px 16px;
+            border-radius: 6px;
+            font-size: 14px;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        
+        .primary-button {
+            background-color: #0077FF;
+            color: white;
+            border: none;
+        }
+        
+        .primary-button:hover {
+            background-color: #0055CC;
+        }
+        
+        .secondary-button {
+            background-color: #F2F2F7;
+            color: #0077FF;
+            border: 1px solid #0077FF;
+        }
+        
+        .secondary-button:hover {
+            background-color: #E5E5EA;
+        }
+        
+        .reset-settings {
+            background-color: transparent;
+            color: #FF3B30;
+            border: 1px solid #FF3B30;
+        }
+        
+        .reset-settings:hover {
+            background-color: #FFEBEE;
+        }
+        
+        .status {
+            margin-top: 16px;
+            padding: 10px;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+        
+        .success {
+            background-color: #E8F5E9;
+            color: #2E7D32;
+        }
+        
+        .error {
+            background-color: #FFEBEE;
+            color: #C62828;
+        }
+        
+        /* Safari-specific instructions */
+        .safari-instructions {
+            background-color: #E3F2FD;
+            border-radius: 6px;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        
+        .safari-instructions h3 {
+            margin-top: 0;
+            color: #1565C0;
+        }
+        
+        .safari-instructions ol {
+            margin-bottom: 0;
+            padding-left: 20px;
+        }
+        
+        .safari-instructions li {
+            margin-bottom: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="settings-container">
+        <h1>ChronicleSync Settings</h1>
+        
+        <div class="safari-instructions">
+            <h3>Safari Extension Setup Instructions</h3>
+            <ol>
+                <li>Open Safari Preferences (⌘,)</li>
+                <li>Go to the Extensions tab</li>
+                <li>Make sure ChronicleSync is enabled</li>
+                <li>Click on ChronicleSync and ensure "All Websites" is selected for permissions</li>
+                <li>Return to this page and configure your settings below</li>
+            </ol>
+        </div>
+        
+        <section class="settings-section">
+            <h2>Configuration</h2>
+            <div id="mnemonicContainer" class="setting-item">
+                <label for="mnemonic">Mnemonic Phrase:</label>
+                <textarea id="mnemonic" placeholder="Enter your 24-word mnemonic phrase" rows="3" required></textarea>
+                <div class="mnemonic-actions">
+                    <button id="generateMnemonic" class="secondary-button">Generate New</button>
+                    <button id="showMnemonic" class="secondary-button">Show/Hide</button>
+                </div>
+                <small class="help-text">Your mnemonic phrase is used to generate your unique client ID. Keep it safe!</small>
+            </div>
+            <div class="setting-item">
+                <label for="clientId">Client ID:</label>
+                <input type="text" id="clientId" placeholder="Generated from mnemonic" readonly>
+            </div>
+            <div class="setting-item">
+                <label for="environment">Environment:</label>
+                <select id="environment" required>
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div id="customUrlContainer" class="setting-item" style="display: none;">
+                <label for="customApiUrl">Custom API URL:</label>
+                <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
+                <small class="help-text">Only used when Environment is set to Custom</small>
+            </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
+        </section>
+
+        <div id="status-container"></div>
+        
+        <div class="settings-actions">
+            <button id="saveSettings" class="primary-button">Save Settings</button>
+            <button id="resetSettings" class="reset-settings">Reset to Default</button>
+        </div>
+    </div>
+    <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/settings.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/settings.js
@@ -1,0 +1,249 @@
+import { getConfig, saveConfig, resetConfig } from './config.js';
+
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+// DOM elements
+let mnemonicInput;
+let clientIdInput;
+let environmentSelect;
+let customUrlContainer;
+let customApiUrlInput;
+let expirationDaysInput;
+let saveSettingsButton;
+let resetSettingsButton;
+let generateMnemonicButton;
+let showMnemonicButton;
+let statusContainer;
+
+// Initialize when the DOM is loaded
+document.addEventListener('DOMContentLoaded', async () => {
+  // Get DOM elements
+  mnemonicInput = document.getElementById('mnemonic');
+  clientIdInput = document.getElementById('clientId');
+  environmentSelect = document.getElementById('environment');
+  customUrlContainer = document.getElementById('customUrlContainer');
+  customApiUrlInput = document.getElementById('customApiUrl');
+  expirationDaysInput = document.getElementById('expirationDays');
+  saveSettingsButton = document.getElementById('saveSettings');
+  resetSettingsButton = document.getElementById('resetSettings');
+  generateMnemonicButton = document.getElementById('generateMnemonic');
+  showMnemonicButton = document.getElementById('showMnemonic');
+  statusContainer = document.getElementById('status-container');
+  
+  // Load current settings
+  await loadSettings();
+  
+  // Set up event listeners
+  environmentSelect.addEventListener('change', toggleCustomUrlVisibility);
+  saveSettingsButton.addEventListener('click', saveSettings);
+  resetSettingsButton.addEventListener('click', resetSettings);
+  generateMnemonicButton.addEventListener('click', generateMnemonic);
+  showMnemonicButton.addEventListener('click', toggleMnemonicVisibility);
+  mnemonicInput.addEventListener('input', updateClientId);
+});
+
+// Load settings from storage
+async function loadSettings() {
+  try {
+    const config = await getConfig();
+    
+    // Populate form fields
+    mnemonicInput.value = config.mnemonic || '';
+    clientIdInput.value = config.clientId === 'extension-default' ? '' : config.clientId;
+    environmentSelect.value = config.environment || 'production';
+    customApiUrlInput.value = config.customApiUrl || '';
+    expirationDaysInput.value = config.expirationDays || 7;
+    
+    // Set mnemonic field type
+    mnemonicInput.type = 'password';
+    
+    // Show/hide custom URL field
+    toggleCustomUrlVisibility();
+    
+    // Update client ID if mnemonic exists
+    if (config.mnemonic) {
+      updateClientId();
+    }
+  } catch (error) {
+    showStatus('Error loading settings: ' + error.message, 'error');
+  }
+}
+
+// Save settings to storage
+async function saveSettings() {
+  try {
+    // Validate inputs
+    const mnemonic = mnemonicInput.value.trim();
+    const environment = environmentSelect.value;
+    const customApiUrl = customApiUrlInput.value.trim();
+    const expirationDays = parseInt(expirationDaysInput.value, 10);
+    
+    if (!mnemonic) {
+      throw new Error('Mnemonic phrase is required');
+    }
+    
+    if (environment === 'custom' && !customApiUrl) {
+      throw new Error('Custom API URL is required when using Custom environment');
+    }
+    
+    if (isNaN(expirationDays) || expirationDays < 1) {
+      throw new Error('History expiration must be at least 1 day');
+    }
+    
+    // Generate client ID from mnemonic
+    const clientId = await generateClientIdFromMnemonic(mnemonic);
+    
+    // Save config
+    const config = {
+      mnemonic,
+      clientId,
+      environment,
+      customApiUrl,
+      expirationDays
+    };
+    
+    const success = await saveConfig(config);
+    
+    if (success) {
+      showStatus('Settings saved successfully!', 'success');
+      
+      // Trigger a sync with the new settings
+      try {
+        await browserAPI.runtime.sendMessage({ type: 'triggerSync' });
+      } catch (error) {
+        console.error('Error triggering sync:', error);
+      }
+    } else {
+      throw new Error('Failed to save settings');
+    }
+  } catch (error) {
+    showStatus('Error: ' + error.message, 'error');
+  }
+}
+
+// Reset settings to defaults
+async function resetSettings() {
+  if (confirm('Are you sure you want to reset all settings to default values?')) {
+    try {
+      const success = await resetConfig();
+      
+      if (success) {
+        await loadSettings();
+        showStatus('Settings reset to defaults', 'success');
+      } else {
+        throw new Error('Failed to reset settings');
+      }
+    } catch (error) {
+      showStatus('Error: ' + error.message, 'error');
+    }
+  }
+}
+
+// Generate a new mnemonic phrase
+async function generateMnemonic() {
+  try {
+    // This is a simplified version - in a real implementation, you'd use a proper BIP39 library
+    const wordlist = [
+      'abandon', 'ability', 'able', 'about', 'above', 'absent', 'absorb', 'abstract', 'absurd', 'abuse',
+      'access', 'accident', 'account', 'accuse', 'achieve', 'acid', 'acoustic', 'acquire', 'across', 'act',
+      'action', 'actor', 'actress', 'actual', 'adapt', 'add', 'addict', 'address', 'adjust', 'admit',
+      'adult', 'advance', 'advice', 'aerobic', 'affair', 'afford', 'afraid', 'again', 'age', 'agent',
+      'agree', 'ahead', 'aim', 'air', 'airport', 'aisle', 'alarm', 'album', 'alcohol', 'alert',
+      'alien', 'all', 'alley', 'allow', 'almost', 'alone', 'alpha', 'already', 'also', 'alter',
+      'always', 'amateur', 'amazing', 'among', 'amount', 'amused', 'analyst', 'anchor', 'ancient', 'anger',
+      'angle', 'angry', 'animal', 'ankle', 'announce', 'annual', 'another', 'answer', 'antenna', 'antique'
+    ];
+    
+    const getRandomWord = () => wordlist[Math.floor(Math.random() * wordlist.length)];
+    const words = Array(24).fill(0).map(() => getRandomWord());
+    
+    mnemonicInput.value = words.join(' ');
+    updateClientId();
+  } catch (error) {
+    showStatus('Error generating mnemonic: ' + error.message, 'error');
+  }
+}
+
+// Toggle mnemonic visibility
+function toggleMnemonicVisibility() {
+  if (mnemonicInput.type === 'password') {
+    mnemonicInput.type = 'text';
+    showMnemonicButton.textContent = 'Hide';
+  } else {
+    mnemonicInput.type = 'password';
+    showMnemonicButton.textContent = 'Show';
+  }
+}
+
+// Update client ID based on mnemonic
+async function updateClientId() {
+  try {
+    const mnemonic = mnemonicInput.value.trim();
+    
+    if (mnemonic) {
+      const clientId = await generateClientIdFromMnemonic(mnemonic);
+      clientIdInput.value = clientId;
+    } else {
+      clientIdInput.value = '';
+    }
+  } catch (error) {
+    console.error('Error updating client ID:', error);
+  }
+}
+
+// Generate client ID from mnemonic
+async function generateClientIdFromMnemonic(mnemonic) {
+  try {
+    // In a real implementation, you'd use a proper crypto library
+    // This is a simplified version that creates a hash-like string
+    
+    // Simple hash function
+    const simpleHash = (str) => {
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32bit integer
+      }
+      return Math.abs(hash).toString(16);
+    };
+    
+    // Generate a client ID based on the mnemonic
+    const hash = simpleHash(mnemonic);
+    const clientId = `cs-${hash.substring(0, 8)}-${hash.substring(8, 16)}`;
+    
+    return clientId;
+  } catch (error) {
+    console.error('Error generating client ID:', error);
+    return 'error-generating-id';
+  }
+}
+
+// Toggle custom URL visibility based on environment selection
+function toggleCustomUrlVisibility() {
+  if (environmentSelect.value === 'custom') {
+    customUrlContainer.style.display = 'block';
+  } else {
+    customUrlContainer.style.display = 'none';
+  }
+}
+
+// Show status message
+function showStatus(message, type) {
+  statusContainer.innerHTML = '';
+  
+  const statusElement = document.createElement('div');
+  statusElement.className = `status ${type}`;
+  statusElement.textContent = message;
+  
+  statusContainer.appendChild(statusElement);
+  
+  // Auto-hide success messages after 5 seconds
+  if (type === 'success') {
+    setTimeout(() => {
+      statusContainer.innerHTML = '';
+    }, 5000);
+  }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/utils/content-extractor.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/utils/content-extractor.js
@@ -1,0 +1,74 @@
+// Utility functions for extracting content from webpages
+
+// Main function to extract page content
+export function extractPageContent() {
+  try {
+    // Get the main content of the page
+    const content = extractMainContent();
+    
+    // Generate a summary
+    const summary = generateSummary(content);
+    
+    return {
+      content,
+      summary
+    };
+  } catch (error) {
+    console.error('Error extracting page content:', error);
+    return {
+      content: '',
+      summary: ''
+    };
+  }
+}
+
+// Extract the main content from the page
+function extractMainContent() {
+  // Try to find the main content element
+  const contentSelectors = [
+    'article',
+    'main',
+    '.content',
+    '.main-content',
+    '#content',
+    '#main-content'
+  ];
+  
+  // Try each selector
+  for (const selector of contentSelectors) {
+    const element = document.querySelector(selector);
+    if (element && element.textContent.trim().length > 100) {
+      return cleanText(element.textContent);
+    }
+  }
+  
+  // If no main content element found, use the body
+  const bodyText = document.body.textContent;
+  return cleanText(bodyText);
+}
+
+// Clean up text content
+function cleanText(text) {
+  return text
+    .replace(/\\s+/g, ' ')
+    .replace(/\\n+/g, ' ')
+    .trim();
+}
+
+// Generate a summary of the content
+function generateSummary(content) {
+  // Simple summary: first 200 characters
+  if (content.length <= 200) {
+    return content;
+  }
+  
+  // Find a good breakpoint (end of sentence) within the first 200-250 chars
+  const firstPart = content.substring(0, 250);
+  const sentenceBreak = firstPart.lastIndexOf('.');
+  
+  if (sentenceBreak > 150) {
+    return content.substring(0, sentenceBreak + 1);
+  }
+  
+  return content.substring(0, 200) + '...';
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/Resources/utils/system.js
+++ b/extension/safari/ChronicleSync/ChronicleSync/Resources/utils/system.js
@@ -1,0 +1,136 @@
+// Utility functions for system information
+
+// Detect browser environment
+const isSafari = typeof browser !== 'undefined' && browser.runtime && browser.runtime.getBrowserInfo;
+const browserAPI = isSafari ? browser : chrome;
+
+// Get system information
+export async function getSystemInfo() {
+  try {
+    // Generate a unique device ID if not already stored
+    let deviceId = await getDeviceId();
+    
+    // Get browser information
+    const browserInfo = await getBrowserInfo();
+    
+    // Get platform information
+    const platformInfo = getPlatformInfo();
+    
+    return {
+      deviceId,
+      name: platformInfo.name,
+      type: platformInfo.type,
+      os: platformInfo.os,
+      browser: browserInfo.name,
+      browserVersion: browserInfo.version
+    };
+  } catch (error) {
+    console.error('Error getting system info:', error);
+    
+    // Return basic info if there's an error
+    return {
+      deviceId: 'unknown-device',
+      name: 'Unknown Device',
+      type: 'unknown',
+      os: 'unknown',
+      browser: isSafari ? 'Safari' : 'Chrome',
+      browserVersion: 'unknown'
+    };
+  }
+}
+
+// Get or generate a device ID
+async function getDeviceId() {
+  try {
+    const data = await browserAPI.storage.local.get(['deviceId']);
+    
+    if (data.deviceId) {
+      return data.deviceId;
+    }
+    
+    // Generate a new device ID
+    const deviceId = generateDeviceId();
+    
+    // Store it for future use
+    await browserAPI.storage.local.set({ deviceId });
+    
+    return deviceId;
+  } catch (error) {
+    console.error('Error getting device ID:', error);
+    return generateDeviceId();
+  }
+}
+
+// Generate a random device ID
+function generateDeviceId() {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let id = 'device-';
+  
+  for (let i = 0; i < 8; i++) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  
+  return id;
+}
+
+// Get browser information
+async function getBrowserInfo() {
+  if (isSafari) {
+    try {
+      const info = await browserAPI.runtime.getBrowserInfo();
+      return {
+        name: info.name || 'Safari',
+        version: info.version || 'unknown'
+      };
+    } catch (error) {
+      return {
+        name: 'Safari',
+        version: 'unknown'
+      };
+    }
+  } else {
+    // Chrome doesn't have a direct API for this
+    const userAgent = navigator.userAgent;
+    const match = userAgent.match(/(chrome|chromium|crios)\\/([0-9.]+)/i);
+    
+    return {
+      name: 'Chrome',
+      version: match ? match[2] : 'unknown'
+    };
+  }
+}
+
+// Get platform information
+function getPlatformInfo() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  
+  // Detect OS
+  let os = 'unknown';
+  let type = 'desktop';
+  let name = 'Unknown Device';
+  
+  if (userAgent.includes('mac os')) {
+    os = 'macOS';
+    name = 'Mac';
+  } else if (userAgent.includes('iphone')) {
+    os = 'iOS';
+    type = 'mobile';
+    name = 'iPhone';
+  } else if (userAgent.includes('ipad')) {
+    os = 'iPadOS';
+    type = 'tablet';
+    name = 'iPad';
+  } else if (userAgent.includes('android')) {
+    os = 'Android';
+    type = userAgent.includes('mobile') ? 'mobile' : 'tablet';
+    name = type === 'mobile' ? 'Android Phone' : 'Android Tablet';
+  } else if (userAgent.includes('windows')) {
+    os = 'Windows';
+    name = 'Windows PC';
+  } else if (userAgent.includes('linux')) {
+    os = 'Linux';
+    name = 'Linux PC';
+  }
+  
+  return { os, type, name };
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/SafariWebExtensionHandler.swift
+++ b/extension/safari/ChronicleSync/ChronicleSync/SafariWebExtensionHandler.swift
@@ -1,0 +1,20 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    
+    let logger = Logger(subsystem: "xyz.chroniclesync.ChronicleSync", category: "Extension")
+    
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey] as? [String: Any]
+        
+        logger.log("Received message from browser.runtime.sendNativeMessage: \(message ?? [:])")
+        
+        let response = NSExtensionItem()
+        response.userInfo = [ SFExtensionMessageKey: [ "Response": "Received message" ] ]
+        
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+    
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/SceneDelegate.swift
+++ b/extension/safari/ChronicleSync/ChronicleSync/SceneDelegate.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}

--- a/extension/safari/ChronicleSync/ChronicleSync/ViewController.swift
+++ b/extension/safari/ChronicleSync/ChronicleSync/ViewController.swift
@@ -1,0 +1,162 @@
+import UIKit
+import SafariServices
+
+class ViewController: UIViewController {
+    
+    // UI Elements
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let setupButton = UIButton(type: .system)
+    private let settingsButton = UIButton(type: .system)
+    private let statusLabel = UILabel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        checkExtensionStatus()
+    }
+    
+    // MARK: - UI Setup
+    
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        
+        // Title Label
+        titleLabel.text = "ChronicleSync"
+        titleLabel.font = UIFont.systemFont(ofSize: 28, weight: .bold)
+        titleLabel.textAlignment = .center
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(titleLabel)
+        
+        // Description Label
+        descriptionLabel.text = "Sync your browsing history across all your devices"
+        descriptionLabel.font = UIFont.systemFont(ofSize: 16)
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(descriptionLabel)
+        
+        // Setup Button
+        setupButton.setTitle("Enable Safari Extension", for: .normal)
+        setupButton.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        setupButton.backgroundColor = .systemBlue
+        setupButton.setTitleColor(.white, for: .normal)
+        setupButton.layer.cornerRadius = 10
+        setupButton.translatesAutoresizingMaskIntoConstraints = false
+        setupButton.addTarget(self, action: #selector(openSafariExtensionSettings), for: .touchUpInside)
+        view.addSubview(setupButton)
+        
+        // Settings Button
+        settingsButton.setTitle("Open Settings", for: .normal)
+        settingsButton.titleLabel?.font = UIFont.systemFont(ofSize: 16)
+        settingsButton.translatesAutoresizingMaskIntoConstraints = false
+        settingsButton.addTarget(self, action: #selector(openSettings), for: .touchUpInside)
+        view.addSubview(settingsButton)
+        
+        // Status Label
+        statusLabel.text = "Extension status: Checking..."
+        statusLabel.font = UIFont.systemFont(ofSize: 14)
+        statusLabel.textAlignment = .center
+        statusLabel.textColor = .secondaryLabel
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(statusLabel)
+        
+        // Setup Constraints
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40),
+            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            descriptionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            descriptionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            descriptionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            
+            setupButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 60),
+            setupButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            setupButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            setupButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            setupButton.heightAnchor.constraint(equalToConstant: 50),
+            
+            settingsButton.topAnchor.constraint(equalTo: setupButton.bottomAnchor, constant: 20),
+            settingsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            statusLabel.topAnchor.constraint(equalTo: settingsButton.bottomAnchor, constant: 40),
+            statusLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            statusLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            statusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
+        ])
+        
+        // Add Safari Extension Setup Instructions
+        addSetupInstructions()
+    }
+    
+    private func addSetupInstructions() {
+        let instructionsView = UIView()
+        instructionsView.backgroundColor = .systemGray6
+        instructionsView.layer.cornerRadius = 10
+        instructionsView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(instructionsView)
+        
+        let instructionsTitle = UILabel()
+        instructionsTitle.text = "How to enable the extension:"
+        instructionsTitle.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        instructionsTitle.translatesAutoresizingMaskIntoConstraints = false
+        instructionsView.addSubview(instructionsTitle)
+        
+        let instructionsText = UILabel()
+        instructionsText.text = "1. Tap 'Enable Safari Extension' above\n2. Enable ChronicleSync\n3. Tap 'All Websites' and select 'Allow'\n4. Return to this app"
+        instructionsText.font = UIFont.systemFont(ofSize: 14)
+        instructionsText.numberOfLines = 0
+        instructionsText.translatesAutoresizingMaskIntoConstraints = false
+        instructionsView.addSubview(instructionsText)
+        
+        NSLayoutConstraint.activate([
+            instructionsView.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 30),
+            instructionsView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            instructionsView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            
+            instructionsTitle.topAnchor.constraint(equalTo: instructionsView.topAnchor, constant: 15),
+            instructionsTitle.leadingAnchor.constraint(equalTo: instructionsView.leadingAnchor, constant: 15),
+            instructionsTitle.trailingAnchor.constraint(equalTo: instructionsView.trailingAnchor, constant: -15),
+            
+            instructionsText.topAnchor.constraint(equalTo: instructionsTitle.bottomAnchor, constant: 10),
+            instructionsText.leadingAnchor.constraint(equalTo: instructionsView.leadingAnchor, constant: 15),
+            instructionsText.trailingAnchor.constraint(equalTo: instructionsView.trailingAnchor, constant: -15),
+            instructionsText.bottomAnchor.constraint(equalTo: instructionsView.bottomAnchor, constant: -15)
+        ])
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func openSafariExtensionSettings() {
+        let safariExtensionURL = URL(string: UIApplication.openSettingsURLString)!
+        UIApplication.shared.open(safariExtensionURL)
+    }
+    
+    @objc private func openSettings() {
+        // Open the settings page in Safari
+        if let url = URL(string: "safari-extension://xyz.chroniclesync.ChronicleSync/settings.html") {
+            let safariVC = SFSafariViewController(url: url)
+            present(safariVC, animated: true)
+        }
+    }
+    
+    // MARK: - Extension Status
+    
+    private func checkExtensionStatus() {
+        // In a real app, you would check if the extension is enabled
+        // For this example, we'll just update the UI
+        
+        // Simulating a check - in a real app, you would use SFSafariExtensionManager
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.statusLabel.text = "Extension status: Not enabled"
+            self.statusLabel.textColor = .systemRed
+        }
+    }
+}

--- a/extension/safari/README.md
+++ b/extension/safari/README.md
@@ -1,0 +1,61 @@
+# ChronicleSync Safari Extension
+
+This is the Safari extension version of ChronicleSync, which allows you to sync your browsing history across devices.
+
+## Features
+
+- Sync browsing history across devices
+- View and search your browsing history
+- Configure sync settings
+- Works on iOS Safari
+
+## Structure
+
+The Safari extension consists of:
+
+1. **iOS App**: The container app that provides instructions and settings
+2. **Safari Web Extension**: The actual extension that runs in Safari
+
+### UI Scenarios
+
+1. **App Launch**: Shows a settings screen with instructions on how to activate the extension in Safari
+2. **Extension Activation**: 
+   - If settings are configured: Activates background and content summary functionality
+   - If settings are not configured: Automatically launches the settings screen
+3. **Extension Click in Browser**: Opens the history view
+
+## Development
+
+### Prerequisites
+
+- Xcode 14.0+
+- iOS 15.0+
+- macOS 12.0+ (for development)
+
+### Building
+
+1. Open `ChronicleSync.xcodeproj` in Xcode
+2. Select your development team
+3. Build and run on a device or simulator
+
+### Testing
+
+Run the tests in Xcode or use the command line:
+
+```bash
+cd ChronicleSync
+xcodebuild test -scheme ChronicleSync -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+```
+
+## Differences from Chrome Extension
+
+The Safari extension is based on the Chrome extension but has some key differences:
+
+1. **Container App**: Safari extensions on iOS require a container app
+2. **Permissions Model**: Safari has a different permissions model than Chrome
+3. **API Compatibility**: Some Chrome APIs are not available in Safari
+4. **Settings Flow**: Safari extensions have different activation and settings flows
+
+## License
+
+Same as the main project


### PR DESCRIPTION
This PR adds a Safari iOS extension based on the existing Chrome extension. The implementation includes:

- Safari web extension files adapted from Chrome extension
- iOS container app for the Safari extension
- UI for three scenarios: app launch, extension activation, and extension click
- Tests for the Safari extension
- GitHub Actions workflow for testing

The Safari extension maintains compatibility with the existing Chrome extension while adding iOS-specific functionality.