### PR TITLE
Add Safari iOS extension wrapper for ChronicleSync

### DIFF
--- a/safari-extension/CHROME_VS_SAFARI.md
+++ b/safari-extension/CHROME_VS_SAFARI.md
@@ -1,0 +1,95 @@
+# Chrome vs. Safari Extensions: Key Differences
+
+When porting a Chrome extension to Safari for iOS, it's important to understand the key differences between the two platforms. This document outlines the main differences and provides guidance on how to address them.
+
+## Manifest Differences
+
+| Feature | Chrome | Safari iOS |
+|---------|--------|------------|
+| Manifest Version | Supports v3 | Supports v3 with limitations |
+| Background | Service workers | Service workers with limitations |
+| Permissions | Extensive list | Limited set |
+| Host Permissions | Flexible | More restricted |
+| Web Accessible Resources | Flexible | Similar to Chrome |
+| Options Page | Supported | Supported but with UI differences |
+
+## API Differences
+
+| API | Chrome | Safari iOS |
+|-----|--------|------------|
+| `chrome.storage` | Full support | Limited support, may need fallbacks |
+| `chrome.history` | Full support | Not available |
+| `chrome.tabs` | Full support | Limited support |
+| `chrome.runtime` | Full support | Limited support |
+| `chrome.scripting` | Full support | Limited support |
+| `chrome.unlimitedStorage` | Available | Not available |
+
+## Workarounds for Safari iOS Limitations
+
+### Storage API
+
+Safari extensions on iOS have limited storage capabilities. Consider these approaches:
+
+1. Use the `safari-api-adapter.js` to provide fallbacks to `localStorage` when needed
+2. For larger storage needs, consider using IndexedDB which is supported in Safari
+3. For shared storage between the app and extension, use App Groups with `UserDefaults`
+
+### History API
+
+The History API is not available in Safari extensions on iOS. Alternatives include:
+
+1. Track visited pages within your extension's own storage
+2. Implement a custom history tracking system using content scripts
+3. Use the native app to provide history functionality
+
+### Background Scripts
+
+Safari on iOS has limitations with background scripts:
+
+1. Background scripts may not run continuously
+2. Use event-based approaches rather than continuous polling
+3. Consider using the native app for tasks that need to run in the background
+
+### Communication
+
+For communication between different parts of your extension:
+
+1. Use `runtime.sendMessage` and `runtime.onMessage` with the adapter
+2. For communication with the native app, use `runtime.sendNativeMessage`
+3. Consider using shared storage for simple data sharing
+
+## Testing and Debugging
+
+Testing and debugging Safari extensions on iOS is different from Chrome:
+
+1. Use Safari's Web Inspector for debugging (enable in Settings > Safari > Advanced)
+2. Test on both simulator and real devices
+3. Be aware that simulator behavior may differ from real devices
+4. Use console logging extensively during development
+
+## User Interface Considerations
+
+Safari on iOS has different UI constraints:
+
+1. Popup UI should be designed for touch interaction
+2. Consider the smaller screen size of mobile devices
+3. Follow iOS design guidelines for a native feel
+4. Test your UI on different device sizes
+
+## Performance Considerations
+
+Mobile devices have different performance characteristics:
+
+1. Minimize resource usage, especially in background scripts
+2. Reduce network requests to conserve battery
+3. Be mindful of memory usage
+4. Consider the impact on battery life
+
+## Security and Privacy
+
+Safari on iOS has stricter security and privacy controls:
+
+1. Respect user privacy and data protection
+2. Be transparent about data collection
+3. Follow Apple's App Store guidelines
+4. Consider implementing App Tracking Transparency if collecting user data

--- a/safari-extension/ContentView.swift.sample
+++ b/safari-extension/ContentView.swift.sample
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "safari")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 100, height: 100)
+                .foregroundColor(.blue)
+            
+            Text("ChronicleSync")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            
+            Text("Safari Extension")
+                .font(.title2)
+            
+            Spacer().frame(height: 30)
+            
+            Text("To enable the extension:")
+                .font(.headline)
+            
+            VStack(alignment: .leading, spacing: 10) {
+                Text("1. Open Settings app")
+                Text("2. Go to Safari > Extensions")
+                Text("3. Enable ChronicleSync Extension")
+                Text("4. Allow permissions when prompted")
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            
+            Spacer().frame(height: 30)
+            
+            Text("About ChronicleSync")
+                .font(.headline)
+            
+            Text("ChronicleSync helps you synchronize your browsing history across devices securely.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            
+            Spacer()
+            
+            Text("© 2025 ChronicleSync")
+                .font(.caption)
+                .foregroundColor(.gray)
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/safari-extension/Info.plist.sample
+++ b/safari-extension/Info.plist.sample
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>ChronicleSync</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.Safari.web-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+        <key>SFSafariContentScript</key>
+        <array>
+            <dict>
+                <key>Script</key>
+                <string>content-script.js</string>
+            </dict>
+        </array>
+        <key>SFSafariWebsiteAccess</key>
+        <dict>
+            <key>Level</key>
+            <string>All</string>
+            <key>Allowed Domains</key>
+            <array>
+                <string>localhost</string>
+                <string>api.chroniclesync.xyz</string>
+                <string>api-staging.chroniclesync.xyz</string>
+            </array>
+        </dict>
+    </dict>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2025 ChronicleSync. All rights reserved.</string>
+    <key>NSHumanReadableDescription</key>
+    <string>ChronicleSync Safari Extension</string>
+</dict>
+</plist>

--- a/safari-extension/README.md
+++ b/safari-extension/README.md
@@ -1,0 +1,62 @@
+# ChronicleSync Safari Extension for iOS
+
+This directory contains the files needed to create a Safari extension for iOS from the ChronicleSync Chrome extension.
+
+## Building the Safari Extension
+
+1. Run the build script to prepare the extension files:
+
+```bash
+# Make the build script executable
+chmod +x build-safari-extension.js
+
+# Run the build script
+node build-safari-extension.js
+```
+
+This will create a directory `ChronicleSync` with all the necessary files for the Safari extension.
+
+## Creating the Xcode Project
+
+1. Open Xcode and create a new project.
+2. Select "Safari Extension App" as the template.
+3. Name your project "ChronicleSync" and configure the other settings as needed.
+4. Once the project is created, you'll need to:
+   - Delete the default `Resources` folder in the Safari Extension target
+   - Add the files from the `ChronicleSync` directory to the Safari Extension target
+
+## Xcode Project Configuration
+
+1. In the Safari Extension target's `Info.plist`, make sure to:
+   - Set `NSExtension > SFSafariWebsiteAccess > Level` to `All`
+   - Add the necessary domains to `NSExtension > SFSafariWebsiteAccess > Allowed Domains` if you want to restrict access
+
+2. In the App target's `Info.plist`, add:
+   ```xml
+   <key>NSAppTransportSecurity</key>
+   <dict>
+       <key>NSAllowsArbitraryLoads</key>
+       <true/>
+   </dict>
+   ```
+
+3. Configure the App Group and other entitlements as needed.
+
+## Testing the Extension
+
+1. Build and run the app on an iOS simulator or device.
+2. Open Safari and go to Settings > Extensions to enable your extension.
+3. Test the extension functionality.
+
+## Known Limitations
+
+- Safari on iOS has more restrictions than desktop Safari or Chrome.
+- Some Chrome APIs may not be fully supported, even with the adapter.
+- The `history` API is not available in Safari extensions on iOS.
+- The `unlimitedStorage` permission is not available in Safari.
+
+## Troubleshooting
+
+- If you encounter issues with API compatibility, check the `safari-api-adapter.js` file and modify it as needed.
+- For debugging, you can use Safari's Web Inspector to debug the extension on iOS devices.
+- Make sure all the necessary permissions are configured in the extension manifest and Xcode project.

--- a/safari-extension/SafariWebExtensionHandler.swift.sample
+++ b/safari-extension/SafariWebExtensionHandler.swift.sample
@@ -1,0 +1,51 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey] as? [String: Any]
+        
+        os_log(.default, "Received message from browser.runtime.sendNativeMessage: %@", message ?? [:])
+        
+        // Handle messages from the extension
+        if let msg = message, let command = msg["command"] as? String {
+            switch command {
+            case "getHistory":
+                // Note: Direct history access is not available in iOS Safari extensions
+                // You would need to implement a workaround or alternative approach
+                let response = NSExtensionItem()
+                response.userInfo = [ SFExtensionMessageKey: [ 
+                    "status": "error",
+                    "message": "History API not available in Safari iOS extensions"
+                ]]
+                context.completeRequest(returningItems: [response], completionHandler: nil)
+                
+            case "getStorage":
+                // Return data from app group storage if needed
+                if let key = msg["key"] as? String {
+                    let userDefaults = UserDefaults(suiteName: "group.com.yourcompany.chroniclesync")
+                    let value = userDefaults?.object(forKey: key)
+                    
+                    let response = NSExtensionItem()
+                    response.userInfo = [ SFExtensionMessageKey: [ 
+                        "status": "success",
+                        "data": value ?? NSNull()
+                    ]]
+                    context.completeRequest(returningItems: [response], completionHandler: nil)
+                }
+                
+            default:
+                // Default response for unknown commands
+                let response = NSExtensionItem()
+                response.userInfo = [ SFExtensionMessageKey: [ "Response": "Unknown command" ] ]
+                context.completeRequest(returningItems: [response], completionHandler: nil)
+            }
+        } else {
+            // Default response
+            let response = NSExtensionItem()
+            response.userInfo = [ SFExtensionMessageKey: [ "Response": "Received" ] ]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+        }
+    }
+}

--- a/safari-extension/XCODE_GUIDE.md
+++ b/safari-extension/XCODE_GUIDE.md
@@ -1,0 +1,168 @@
+# Xcode Project Setup Guide for ChronicleSync Safari Extension
+
+This guide provides step-by-step instructions for setting up an Xcode project to create a Safari extension for iOS.
+
+## Creating a New Xcode Project
+
+1. Open Xcode and select "Create a new Xcode project"
+2. Choose "iOS" as the platform and select "App" as the template
+3. Click "Next"
+4. Enter the following details:
+   - Product Name: ChronicleSync
+   - Team: Select your development team
+   - Organization Identifier: com.yourcompany (replace with your identifier)
+   - Bundle Identifier: will be automatically generated
+   - Language: Swift
+   - User Interface: SwiftUI
+   - Uncheck "Use Core Data" and "Include Tests"
+5. Click "Next" and choose a location to save the project
+6. Click "Create"
+
+## Adding the Safari Extension Target
+
+1. In Xcode, go to File > New > Target
+2. Select "Safari Extension" under the "iOS" tab
+3. Click "Next"
+4. Enter the following details:
+   - Product Name: ChronicleSync Extension
+   - Team: Same as your main app
+   - Organization Identifier: Same as your main app
+   - Bundle Identifier: will be automatically generated
+   - Language: Swift
+5. Click "Finish"
+6. If prompted to activate the scheme, click "Activate"
+
+## Configuring the Safari Extension
+
+1. In the Project Navigator, select the Safari Extension target
+2. Go to the "General" tab and ensure:
+   - Deployment Info is set to iOS 14.0 or later
+   - App Category is set to "Utilities" or appropriate category
+
+3. Go to the "Signing & Capabilities" tab:
+   - Ensure "Automatically manage signing" is checked
+   - Select your development team
+
+4. Add the "App Groups" capability:
+   - Click the "+" button in the Capabilities section
+   - Select "App Groups"
+   - Click the "+" button under App Groups and create a group identifier (e.g., "group.com.yourcompany.chroniclesync")
+   - Add the same App Group to both the main app and extension targets
+
+## Importing the Extension Files
+
+1. In the Project Navigator, select the Safari Extension target
+2. Delete the default "Resources" folder (right-click > Delete > Move to Trash)
+3. Right-click on the Safari Extension target and select "Add Files to [Target]..."
+4. Navigate to the location of your extracted ChronicleSync-Safari-Extension.zip files
+5. Select all files and ensure:
+   - "Copy items if needed" is checked
+   - "Create groups" is selected
+   - Your Safari Extension target is checked under "Add to targets"
+6. Click "Add"
+
+## Configuring Info.plist
+
+1. In the Project Navigator, find the Info.plist file for your Safari Extension target
+2. Add or modify the following entries:
+   - NSExtension > NSExtensionPointIdentifier: com.apple.Safari.web-extension
+   - NSExtension > SFSafariWebsiteAccess > Level: All
+   - NSExtension > SFSafariContentScript: Add an array with your content script entries
+
+## Creating the Swift Interface
+
+1. Open the SafariWebExtensionHandler.swift file
+2. Replace its contents with:
+
+```swift
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey] as? [String: Any]
+        
+        os_log(.default, "Received message from browser.runtime.sendNativeMessage: %@", message ?? [:])
+        
+        let response = NSExtensionItem()
+        response.userInfo = [ SFExtensionMessageKey: [ "Response": "Received" ] ]
+        
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+}
+```
+
+## Configuring the Main App
+
+1. Open the main app's ContentView.swift file
+2. Replace its contents with:
+
+```swift
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "safari")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 100, height: 100)
+                .foregroundColor(.blue)
+            
+            Text("ChronicleSync")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            
+            Text("Safari Extension")
+                .font(.title2)
+            
+            Spacer().frame(height: 30)
+            
+            Text("To enable the extension:")
+                .font(.headline)
+            
+            VStack(alignment: .leading, spacing: 10) {
+                Text("1. Open Settings app")
+                Text("2. Go to Safari > Extensions")
+                Text("3. Enable ChronicleSync Extension")
+                Text("4. Allow permissions when prompted")
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            
+            Spacer()
+            
+            Text("© 2025 ChronicleSync")
+                .font(.caption)
+                .foregroundColor(.gray)
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
+```
+
+## Building and Testing
+
+1. Select the main app scheme from the scheme selector
+2. Choose an iOS device or simulator as the destination
+3. Click the "Run" button to build and run the app
+4. Once the app is running:
+   - Open Safari
+   - Go to Settings > Safari > Extensions
+   - Enable your extension
+   - Test the extension functionality
+
+## Troubleshooting
+
+- If you encounter build errors, check that all files are properly added to the target
+- Ensure all required permissions are set in the Info.plist
+- For debugging, use Safari's Web Inspector (enable in Settings > Safari > Advanced > Web Inspector)
+- Check the console logs for any error messages

--- a/safari-extension/build-safari-extension.js
+++ b/safari-extension/build-safari-extension.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const { mkdir, rm, cp, readFile, writeFile } = require('fs/promises');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const { join } = require('path');
+const { existsSync } = require('fs');
+
+const execAsync = promisify(exec);
+const ROOT_DIR = join(__dirname, '..');  // Repository root directory
+const EXTENSION_DIR = join(ROOT_DIR, 'extension');  // Chrome extension directory
+const SAFARI_DIR = join(__dirname, 'ChronicleSync');  // Safari extension directory
+
+/** @type {[string, string][]} File copy specifications [source, destination] */
+const filesToCopy = [
+  ['popup.html', 'popup.html'],
+  ['popup.css', 'popup.css'],
+  ['settings.html', 'settings.html'],
+  ['settings.css', 'settings.css'],
+  ['history.html', 'history.html'],
+  ['history.css', 'history.css'],
+  ['devtools.html', 'devtools.html'],
+  ['devtools.css', 'devtools.css'],
+  ['bip39-wordlist.js', 'bip39-wordlist.js']
+];
+
+async function main() {
+  try {
+    // Clean up any existing files
+    if (existsSync(SAFARI_DIR)) {
+      await rm(SAFARI_DIR, { recursive: true, force: true });
+    }
+    
+    // Create Safari extension directory
+    await mkdir(SAFARI_DIR, { recursive: true });
+    
+    // Install dependencies and build the Chrome extension
+    console.log('Installing dependencies...');
+    await execAsync('npm install', { cwd: EXTENSION_DIR });
+    
+    console.log('Building Chrome extension...');
+    await execAsync('npm run build', { cwd: EXTENSION_DIR });
+    
+    // Copy static files
+    console.log('Copying files...');
+    for (const [src, dest] of filesToCopy) {
+      await cp(
+        join(EXTENSION_DIR, src),
+        join(SAFARI_DIR, dest),
+        { recursive: true }
+      ).catch(err => {
+        console.warn(`Warning: Could not copy ${src}: ${err.message}`);
+      });
+    }
+    
+    // Copy built JS files
+    const distFiles = [
+      'popup.js',
+      'background.js',
+      'settings.js',
+      'history.js',
+      'devtools.js',
+      'devtools-page.js',
+      'content-script.js'
+    ];
+    
+    for (const file of distFiles) {
+      await cp(
+        join(EXTENSION_DIR, 'dist', file),
+        join(SAFARI_DIR, file),
+        { recursive: true }
+      ).catch(err => {
+        console.warn(`Warning: Could not copy ${file}: ${err.message}`);
+      });
+    }
+    
+    // Copy assets directory
+    await cp(
+      join(EXTENSION_DIR, 'dist', 'assets'),
+      join(SAFARI_DIR, 'assets'),
+      { recursive: true }
+    ).catch(err => {
+      console.warn(`Warning: Could not copy assets: ${err.message}`);
+    });
+    
+    // Copy the Safari-specific manifest.json (already created)
+    // This step is skipped as we've already created a custom manifest.json for Safari
+    
+    console.log('Safari extension files prepared successfully!');
+    console.log('Next steps:');
+    console.log('1. Create a new Safari App Extension project in Xcode');
+    console.log('2. Copy the files from the safari-extension/ChronicleSync directory to your Xcode project');
+    console.log('3. Configure the extension in Xcode and build for iOS');
+    
+  } catch (error) {
+    console.error('Error building Safari extension:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/safari-extension/build.sh
+++ b/safari-extension/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Build script for ChronicleSync Safari Extension
+
+echo "Building ChronicleSync Safari Extension..."
+echo "This process may take several minutes as it needs to install dependencies and build the extension."
+
+# Step 1: Build the extension files
+echo "Step 1/3: Building extension files..."
+node build-safari-extension.js
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to build extension files. See error messages above."
+    exit 1
+fi
+
+# Step 2: Modify JS files to use Safari API adapter
+echo "Step 2/3: Modifying JS files to use Safari API adapter..."
+node modify-js-files.js
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to modify JS files. See error messages above."
+    exit 1
+fi
+
+# Step 3: Create a zip file for easy import into Xcode
+echo "Step 3/3: Creating zip file for Xcode import..."
+if [ -d "ChronicleSync" ]; then
+    cd ChronicleSync
+    zip -r ../ChronicleSync-Safari-Extension.zip ./*
+    cd ..
+    echo "Build complete! ChronicleSync-Safari-Extension.zip is ready for import into Xcode."
+else
+    echo "Error: ChronicleSync directory not found. Build may have failed."
+    exit 1
+fi
+
+echo ""
+echo "Next steps for iOS Safari Extension:"
+echo "1. Create a new Safari Extension App project in Xcode"
+echo "2. Import the files from ChronicleSync-Safari-Extension.zip"
+echo "3. Configure the extension in Xcode and build for iOS"
+echo ""
+echo "Documentation:"
+echo "- README.md: General instructions"
+echo "- XCODE_GUIDE.md: Detailed Xcode setup guide"
+echo "- CHROME_VS_SAFARI.md: Key differences between Chrome and Safari extensions"
+echo ""
+echo "Note: Some Chrome APIs are not available in Safari on iOS."
+echo "See CHROME_VS_SAFARI.md for details and workarounds."

--- a/safari-extension/modify-js-files.js
+++ b/safari-extension/modify-js-files.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+const { readdir, readFile, writeFile } = require('fs/promises');
+const { join } = require('path');
+
+const SAFARI_DIR = join(__dirname, 'ChronicleSync');
+
+// The adapter script to be injected at the beginning of each JS file
+const ADAPTER_IMPORT = `
+// Safari API adapter import
+if (typeof window !== 'undefined') {
+  const script = document.createElement('script');
+  script.src = chrome.runtime.getURL('safari-api-adapter.js');
+  (document.head || document.documentElement).appendChild(script);
+  script.onload = function() {
+    script.remove();
+  };
+}
+
+// Use browserAPI instead of chrome
+const chrome = window.browserAPI || chrome;
+`;
+
+async function modifyJSFiles() {
+  try {
+    // Get all JS files in the Safari extension directory
+    const files = await readdir(SAFARI_DIR);
+    const jsFiles = files.filter(file => file.endsWith('.js') && file !== 'safari-api-adapter.js');
+    
+    for (const file of jsFiles) {
+      const filePath = join(SAFARI_DIR, file);
+      let content = await readFile(filePath, 'utf8');
+      
+      // Skip if the file already has the adapter import
+      if (content.includes('safari-api-adapter.js')) {
+        console.log(`Skipping ${file} - already modified`);
+        continue;
+      }
+      
+      // Add the adapter import at the beginning of the file
+      content = ADAPTER_IMPORT + content;
+      
+      // Replace direct chrome API calls with browserAPI
+      // This is a simple replacement and might need more sophisticated handling
+      // content = content.replace(/chrome\./g, 'browserAPI.');
+      
+      // Write the modified content back to the file
+      await writeFile(filePath, content, 'utf8');
+      console.log(`Modified ${file}`);
+    }
+    
+    console.log('All JS files have been modified to use the Safari API adapter');
+  } catch (error) {
+    console.error('Error modifying JS files:', error);
+  }
+}
+
+modifyJSFiles();


### PR DESCRIPTION
This PR adds support for wrapping the Chrome extension as a Safari extension for iOS. It includes:

- Build scripts to prepare the extension files for Safari
- Safari API adapter to handle browser API differences
- Documentation on how to create an Xcode project
- Sample Swift files for the iOS app
- Detailed guides on Chrome vs Safari extension differences

To use this:
1. Run the build script in the safari-extension directory
2. Create a new Safari Extension App project in Xcode
3. Import the generated files
4. Configure the extension in Xcode and build for iOS