### PR TITLE
Only search and store summaries, never content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # ChronicleSync
 
-Sync stuff across browsers
+Sync browsing history and summaries across browsers
 
 ## Features
 
 - **Offline-First**: Continue working without internet connection with automatic background sync
+- **Privacy-Focused**: Only syncs summaries and history information, never stores or syncs full page content
+- **Efficient Search**: Search through summaries and history information, not full content
 - **Not Secure**: I'm to lazy and the models suck too much for local encryption, but it's coming.
 - **Not Multiplatform**: We haven't added IOS support cause basic stuff still doesn't work.
 - **Real-time Monitoring**: Health monitoring and administrative dashboard

--- a/extension/e2e/summary-search.spec.ts
+++ b/extension/e2e/summary-search.spec.ts
@@ -8,8 +8,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-test.describe('Content Search', () => {
-  test('should extract and search webpage content', async ({ context, extensionId }) => {
+test.describe('Summary Search', () => {
+  test('should extract and search webpage summaries', async ({ context, extensionId }) => {
     test.setTimeout(120000); // Increase timeout to 2 minutes
     // First, set up a client ID through the settings page
     const settingsPage = await context.newPage();
@@ -100,11 +100,11 @@ test.describe('Content Search', () => {
     await historyPage.goto(getExtensionUrl(extensionId, 'history.html'));
     await historyPage.waitForTimeout(1000);
 
-    // Switch to content search tab
-    await historyPage.locator('.search-tab:text("Content Search")').click();
+    // Switch to summary search tab
+    await historyPage.locator('.search-tab:text("Summary Search")').click();
     await historyPage.waitForTimeout(500);
 
-    // Verify content search UI is visible
+    // Verify summary search UI is visible
     await expect(historyPage.locator('.search-input')).toBeVisible();
     await expect(historyPage.locator('.search-button')).toBeVisible();
 
@@ -189,10 +189,10 @@ test.describe('Content Search', () => {
     const blockchainResults = await historyPage.locator('.search-result-item').count();
     console.log(`Found ${blockchainResults} results for "blockchain technology"`);
     
-    // At least one of our content searches should return results
-    const totalContentSearchResults = phraseResults + quantumResults + blockchainResults;
-    console.log(`Total content search results across all queries: ${totalContentSearchResults}`);
-    expect(totalContentSearchResults).toBeGreaterThan(0);
+    // At least one of our summary searches should return results
+    const totalSummarySearchResults = phraseResults + quantumResults + blockchainResults;
+    console.log(`Total summary search results across all queries: ${totalSummarySearchResults}`);
+    expect(totalSummarySearchResults).toBeGreaterThan(0);
 
     // Test 8: Verify page summaries are displayed (if available)
     // Clear search results first
@@ -223,7 +223,7 @@ test.describe('Content Search', () => {
 
     // Take a screenshot of the final state
     await historyPage.screenshot({
-      path: 'test-results/content-search.png',
+      path: 'test-results/summary-search.png',
       fullPage: true
     });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -278,7 +278,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       historyStore.init().then(async () => {
         try {
           // We pass an empty string for content as we never store or sync content
-          await historyStore.updatePageContent(url, { content: "", summary });
+          await historyStore.updatePageContent(url, { content: '', summary });
           console.debug('Updated page summary for:', url);
           sendResponse({ success: true });
           

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -281,8 +281,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           console.debug('Updated page content for:', url);
           sendResponse({ success: true });
           
-          // Trigger a sync to send the updated content to the server
-          setTimeout(() => syncHistory(false), 1000);
+          // We no longer sync content, only summaries
+          // No need to trigger a sync here
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           console.error('Error updating page content:', errorMessage);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -272,20 +272,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true; // Will respond asynchronously
   } else if (request.type === 'pageContentExtracted') {
     // Handle page content extraction from content script
-    const { url, content, summary } = request.data;
-    if (url && (content || summary)) {
+    const { url, summary } = request.data;
+    if (url && summary) {
       const historyStore = new HistoryStore();
       historyStore.init().then(async () => {
         try {
-          await historyStore.updatePageContent(url, { content, summary });
-          console.debug('Updated page content for:', url);
+          // We pass an empty string for content as we never store or sync content
+          await historyStore.updatePageContent(url, { content: "", summary });
+          console.debug('Updated page summary for:', url);
           sendResponse({ success: true });
           
-          // We no longer sync content, only summaries
+          // We never sync content, only summaries
           // No need to trigger a sync here
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
-          console.error('Error updating page content:', errorMessage);
+          console.error('Error updating page summary:', errorMessage);
           sendResponse({ error: errorMessage });
         }
       }).catch(error => {

--- a/extension/src/components/SearchHistory.tsx
+++ b/extension/src/components/SearchHistory.tsx
@@ -47,7 +47,7 @@ export const SearchHistory: React.FC<SearchHistoryProps> = ({ onSearchComplete }
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search summaries and history..."
+            placeholder="Search summaries and history information only..."
             className="search-input"
           />
           <button 

--- a/extension/src/components/SearchHistory.tsx
+++ b/extension/src/components/SearchHistory.tsx
@@ -47,7 +47,7 @@ export const SearchHistory: React.FC<SearchHistoryProps> = ({ onSearchComplete }
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search page content..."
+            placeholder="Search summaries and history..."
             className="search-input"
           />
           <button 

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -4,16 +4,19 @@ import { extractPageContent } from './utils/content-extractor';
 // Extract content when the page loads
 function processPageContent() {
   try {
+    // Extract content and generate summary
+    // Note: Content is only used locally for summary generation and is never stored or synced
     const pageContent = extractPageContent();
     
-    // Send the extracted content to the background script
+    // Send ONLY the summary to the background script
+    // The content is included here but will be discarded by the background script
     chrome.runtime.sendMessage({
       type: 'pageContentExtracted',
       data: {
         url: window.location.href,
         title: document.title,
-        content: pageContent.content,
-        summary: pageContent.summary,
+        content: pageContent.content, // This will be discarded by the background script
+        summary: pageContent.summary, // Only the summary is stored
         timestamp: Date.now()
       }
     });
@@ -28,5 +31,5 @@ window.addEventListener('load', () => {
   setTimeout(processPageContent, 1000);
 });
 
-// We no longer need to search page content directly
-// All searches will be done through the background script using stored summaries
+// We never search content directly
+// All searches are done through the background script using only summaries and history information

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -28,47 +28,5 @@ window.addEventListener('load', () => {
   setTimeout(processPageContent, 1000);
 });
 
-// Listen for messages from the background script
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.type === 'searchPageContent') {
-    const { query } = request;
-    try {
-      const pageContent = extractPageContent();
-      const searchResults = searchContent(pageContent.content, query);
-      sendResponse({ success: true, results: searchResults });
-    } catch (error) {
-      sendResponse({ success: false, error: String(error) });
-    }
-    return true; // Will respond asynchronously
-  }
-});
-
-// Function to search content and return matches with context
-function searchContent(content: string, query: string): { text: string, context: string }[] {
-  if (!query || !content) return [];
-  
-  const results: { text: string, context: string }[] = [];
-  const lowerContent = content.toLowerCase();
-  const lowerQuery = query.toLowerCase();
-  
-  let startIndex = 0;
-  while (startIndex < lowerContent.length) {
-    const foundIndex = lowerContent.indexOf(lowerQuery, startIndex);
-    if (foundIndex === -1) break;
-    
-    // Get context around the match (100 chars before and after)
-    const contextStart = Math.max(0, foundIndex - 100);
-    const contextEnd = Math.min(content.length, foundIndex + query.length + 100);
-    const matchText = content.substring(foundIndex, foundIndex + query.length);
-    const context = content.substring(contextStart, contextEnd);
-    
-    results.push({
-      text: matchText,
-      context: context
-    });
-    
-    startIndex = foundIndex + query.length;
-  }
-  
-  return results;
-}
+// We no longer need to search page content directly
+// All searches will be done through the background script using stored summaries

--- a/extension/src/db/HistoryStore.ts
+++ b/extension/src/db/HistoryStore.ts
@@ -306,7 +306,7 @@ export class HistoryStore {
           
           // Update the entry with ONLY the summary (not the content)
           mostRecentEntry.pageContent = {
-            content: "", // Don't store content, only use it for summary generation
+            content: "", // Never store content, only use it for summary generation
             summary: pageContent.summary,
             extractedAt: Date.now()
           };
@@ -338,20 +338,16 @@ export class HistoryStore {
         const entries = request.result || [];
         const results: { entry: HistoryEntry, matches: { text: string, context: string }[] }[] = [];
         
-        // Filter entries with page content (summary) and not deleted
-        const entriesWithSummary = entries.filter(entry => 
-          !entry.deleted && 
-          entry.pageContent && 
-          entry.pageContent.summary
-        );
+        // Filter entries that are not deleted
+        const validEntries = entries.filter(entry => !entry.deleted);
         
         // Search for query in summary and history information (title, url)
         const lowerQuery = query.toLowerCase();
         
-        for (const entry of entriesWithSummary) {
+        for (const entry of validEntries) {
           const matches: { text: string, context: string }[] = [];
           
-          // Search in summary
+          // Search in summary (if available)
           if (entry.pageContent?.summary) {
             const summary = entry.pageContent.summary.toLowerCase();
             let startIndex = 0;

--- a/extension/src/db/HistoryStore.ts
+++ b/extension/src/db/HistoryStore.ts
@@ -304,9 +304,9 @@ export class HistoryStore {
             return current.visitTime > latest.visitTime ? current : latest;
           }, entries[0]);
           
-          // Update the entry with page content
+          // Update the entry with ONLY the summary (not the content)
           mostRecentEntry.pageContent = {
-            content: pageContent.content,
+            content: "", // Don't store content, only use it for summary generation
             summary: pageContent.summary,
             extractedAt: Date.now()
           };
@@ -338,37 +338,61 @@ export class HistoryStore {
         const entries = request.result || [];
         const results: { entry: HistoryEntry, matches: { text: string, context: string }[] }[] = [];
         
-        // Filter entries with page content and not deleted
-        const entriesWithContent = entries.filter(entry => 
+        // Filter entries with page content (summary) and not deleted
+        const entriesWithSummary = entries.filter(entry => 
           !entry.deleted && 
           entry.pageContent && 
-          entry.pageContent.content
+          entry.pageContent.summary
         );
         
-        // Search for query in content
+        // Search for query in summary and history information (title, url)
         const lowerQuery = query.toLowerCase();
         
-        for (const entry of entriesWithContent) {
-          const content = entry.pageContent!.content.toLowerCase();
+        for (const entry of entriesWithSummary) {
           const matches: { text: string, context: string }[] = [];
           
-          let startIndex = 0;
-          while (startIndex < content.length) {
-            const foundIndex = content.indexOf(lowerQuery, startIndex);
-            if (foundIndex === -1) break;
+          // Search in summary
+          if (entry.pageContent?.summary) {
+            const summary = entry.pageContent.summary.toLowerCase();
+            let startIndex = 0;
             
-            // Get context around the match (100 chars before and after)
-            const contextStart = Math.max(0, foundIndex - 100);
-            const contextEnd = Math.min(content.length, foundIndex + query.length + 100);
-            const matchText = entry.pageContent!.content.substring(foundIndex, foundIndex + query.length);
-            const context = entry.pageContent!.content.substring(contextStart, contextEnd);
-            
-            matches.push({
-              text: matchText,
-              context: context
-            });
-            
-            startIndex = foundIndex + query.length;
+            while (startIndex < summary.length) {
+              const foundIndex = summary.indexOf(lowerQuery, startIndex);
+              if (foundIndex === -1) break;
+              
+              // Get context around the match (entire summary is the context)
+              const matchText = entry.pageContent.summary.substring(foundIndex, foundIndex + query.length);
+              const context = entry.pageContent.summary;
+              
+              matches.push({
+                text: matchText,
+                context: context
+              });
+              
+              startIndex = foundIndex + query.length;
+            }
+          }
+          
+          // Search in title
+          if (entry.title) {
+            const title = entry.title.toLowerCase();
+            if (title.includes(lowerQuery)) {
+              matches.push({
+                text: query,
+                context: `Title: ${entry.title}`
+              });
+            }
+          }
+          
+          // Search in URL
+          if (entry.url) {
+            const url = entry.url.toLowerCase();
+            if (url.includes(lowerQuery)) {
+              matches.push({
+                text: query,
+                context: `URL: ${entry.url}`
+              });
+            }
           }
           
           if (matches.length > 0) {

--- a/extension/src/db/HistoryStore.ts
+++ b/extension/src/db/HistoryStore.ts
@@ -306,7 +306,7 @@ export class HistoryStore {
           
           // Update the entry with ONLY the summary (not the content)
           mostRecentEntry.pageContent = {
-            content: "", // Never store content, only use it for summary generation
+            content: '', // Never store content, only use it for summary generation
             summary: pageContent.summary,
             extractedAt: Date.now()
           };

--- a/extension/src/history.tsx
+++ b/extension/src/history.tsx
@@ -60,7 +60,7 @@ const HistoryView: React.FC = () => {
     setCurrentPage(1);
   }, [searchTerm, filters, history, showingSearchResults]);
   
-  const handleContentSearchComplete = (results: SearchResult[]) => {
+  const handleSummarySearchComplete = (results: SearchResult[]) => {
     setSearchResults(results);
     setShowingSearchResults(true);
   };
@@ -109,13 +109,13 @@ const HistoryView: React.FC = () => {
           Basic Search
         </div>
         <div className={`search-tab ${showingSearchResults ? 'active' : ''}`} onClick={() => setShowingSearchResults(true)}>
-          Content Search
+          Summary Search
         </div>
       </div>
       
       {showingSearchResults ? (
-        <div className="content-search-container">
-          <SearchHistory onSearchComplete={handleContentSearchComplete} />
+        <div className="summary-search-container">
+          <SearchHistory onSearchComplete={handleSummarySearchComplete} />
           <SearchResults results={searchResults} onClearResults={handleClearSearchResults} />
         </div>
       ) : (

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -7,7 +7,7 @@ export interface DeviceInfo {
 }
 
 export interface PageContent {
-  content: string;
+  content: string; // This will be empty in storage, only used for summary generation
   summary: string;
   extractedAt: number;
 }

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -7,8 +7,8 @@ export interface DeviceInfo {
 }
 
 export interface PageContent {
-  content: string; // This will be empty in storage, only used for summary generation
-  summary: string;
+  content: string; // This will ALWAYS be empty in storage, NEVER stored or synced, only used locally for summary generation
+  summary: string; // Only the summary is stored and searched
   extractedAt: number;
 }
 

--- a/extension/src/utils/content-extractor.ts
+++ b/extension/src/utils/content-extractor.ts
@@ -6,8 +6,9 @@ interface PageContent {
 }
 
 /**
- * Extract the main content from the current webpage
- * @returns Object containing the extracted content and a summary
+ * Extract the main content from the current webpage and generate a summary
+ * Note: The content is only used for summary generation and is not stored or synced
+ * @returns Object containing the extracted content (for summary generation only) and a summary
  */
 export function extractPageContent(): PageContent {
   // Extract the main content from the page
@@ -17,7 +18,7 @@ export function extractPageContent(): PageContent {
   const summary = generateSummary(content);
   
   return {
-    content,
+    content, // This is only used for summary generation and will not be stored
     summary
   };
 }

--- a/extension/src/utils/content-extractor.ts
+++ b/extension/src/utils/content-extractor.ts
@@ -1,13 +1,13 @@
 // Utility to extract and summarize webpage content
 
 interface PageContent {
-  content: string;
-  summary: string;
+  content: string; // Only used locally for summary generation, never stored or synced
+  summary: string; // This is what gets stored and searched
 }
 
 /**
  * Extract the main content from the current webpage and generate a summary
- * Note: The content is only used for summary generation and is not stored or synced
+ * IMPORTANT: The content is ONLY used for summary generation and is NEVER stored or synced
  * @returns Object containing the extracted content (for summary generation only) and a summary
  */
 export function extractPageContent(): PageContent {
@@ -18,8 +18,8 @@ export function extractPageContent(): PageContent {
   const summary = generateSummary(content);
   
   return {
-    content, // This is only used for summary generation and will not be stored
-    summary
+    content, // This is ONLY used for summary generation and will NEVER be stored or synced
+    summary  // Only the summary is stored and used for searching
   };
 }
 


### PR DESCRIPTION
This PR modifies the project to:

1. Never search content, only search summaries and history information
2. Never sync or store content, only use it locally to generate summaries
3. Update documentation and comments to make this behavior clear

Content is now only used locally to generate summaries and is never stored or synced.