### PR TITLE
Switch build job to macOS GitHub Actions runner

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -117,7 +117,7 @@ jobs:
       matrix:
         browser: [chrome, firefox]
         # Future platforms can be added here (e.g., ios, android)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       # Skip this job if a specific browser is requested in workflow_dispatch and it's not this one
       - name: Check if this browser should be tested

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     outputs:
       current_version: ${{ steps.deploy-worker.outputs.current_version }}

--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Package Extensions
         working-directory: extension
         run: |
-          # Install zip utility
-          sudo apt-get update && sudo apt-get install -y zip
+          # macOS already has zip utility installed
           # Run build script with ESM support
           NODE_OPTIONS="--experimental-vm-modules --no-warnings" npm run build:extension
 
@@ -118,7 +117,7 @@ jobs:
       matrix:
         browser: [chrome, firefox]
         # Future platforms can be added here (e.g., ios, android)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       # Skip this job if a specific browser is requested in workflow_dispatch and it's not this one
       - name: Check if this browser should be tested


### PR DESCRIPTION
This PR switches the build-and-test job in ci-cd-combined.yml workflow to use macOS GitHub Actions runners instead of Ubuntu runners. The playwright-extension-tests job and pages.yml workflow remain unchanged with Ubuntu runners.

Changes:
- Changed `runs-on: ubuntu-latest` to `runs-on: macos-latest` for the build-and-test job
- Updated Package Extensions step to remove Ubuntu-specific commands (apt-get install zip)
- Kept playwright-extension-tests job on Ubuntu runners