### PR TITLE
Use GitHub repository variables for Safari extension configuration

### DIFF
--- a/.github/workflows/ci-cd-combined.yml
+++ b/.github/workflows/ci-cd-combined.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Generate Safari IPA
         working-directory: extension
         env:
-          APP_NAME: "ChronicleSync"
-          BUNDLE_ID: "com.chroniclesync.safari-extension"
+          APP_NAME: ${{ vars.SAFARI_APP_NAME || 'ChronicleSync' }}
+          BUNDLE_ID: ${{ vars.SAFARI_BUNDLE_ID || 'com.chroniclesync.safari-extension' }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
         run: |
@@ -255,8 +255,8 @@ jobs:
         id: create-simulator
         working-directory: extension
         env:
-          APP_NAME: "ChronicleSync"
-          BUNDLE_ID: "com.chroniclesync.safari-extension"
+          APP_NAME: ${{ vars.SAFARI_APP_NAME || 'ChronicleSync' }}
+          BUNDLE_ID: ${{ vars.SAFARI_BUNDLE_ID || 'com.chroniclesync.safari-extension' }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
         run: |
@@ -269,8 +269,8 @@ jobs:
         if: steps.should_test.outputs.should_test == 'true'
         working-directory: extension
         env:
-          APP_NAME: "ChronicleSync"
-          BUNDLE_ID: "com.chroniclesync.safari-extension"
+          APP_NAME: ${{ vars.SAFARI_APP_NAME || 'ChronicleSync' }}
+          BUNDLE_ID: ${{ vars.SAFARI_BUNDLE_ID || 'com.chroniclesync.safari-extension' }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
         run: |

--- a/extension/scripts/generate-safari-files.js
+++ b/extension/scripts/generate-safari-files.js
@@ -22,7 +22,7 @@ const APPLE_TEAM_ID = process.env.APPLE_TEAM_ID || '';
 const APPLE_APP_ID = process.env.APPLE_APP_ID || '';
 
 // Paths
-const SCRIPTS_DIR = process.cwd();
+const SCRIPTS_DIR = join(process.cwd(), 'scripts');
 const TEMPLATES_DIR = join(SCRIPTS_DIR, 'templates');
 
 // Template files


### PR DESCRIPTION
## Changes

- Updated GitHub workflow to use repository variables for Safari app name and bundle ID
- Fixed path in generate-safari-files.js to correctly locate template files
- Added fallback values for backward compatibility

## Benefits

- Improved maintainability by centralizing configuration values
- Allows changing app name and bundle ID without modifying workflow files
- Ensures consistent use of GitHub secrets for sensitive information (APPLE_TEAM_ID and APPLE_APP_ID)

## Testing

- Verified template generation works correctly with test values
- Confirmed placeholders are properly replaced in generated files